### PR TITLE
feat: 장소 도장 찍기 기능 구현 및 단위 테스트

### DIFF
--- a/src/main/java/region/jidogam/common/config/TimeConfig.java
+++ b/src/main/java/region/jidogam/common/config/TimeConfig.java
@@ -1,0 +1,14 @@
+package region.jidogam.common.config;
+
+import java.time.Clock;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TimeConfig {
+
+  @Bean
+  public Clock clock() {
+    return Clock.systemDefaultZone();
+  }
+}

--- a/src/main/java/region/jidogam/domain/area/exception/AreaErrorCode.java
+++ b/src/main/java/region/jidogam/domain/area/exception/AreaErrorCode.java
@@ -6,7 +6,8 @@ import region.jidogam.common.exception.ErrorCode;
 
 @Getter
 public enum AreaErrorCode implements ErrorCode {
-  UNKNOWN_SIDO(HttpStatus.BAD_REQUEST, "AREA_001", "잘못된 시도 값입니다.");
+  UNKNOWN_SIDO(HttpStatus.BAD_REQUEST, "AREA_001", "잘못된 시도 값입니다."),
+  AREA_NOT_FOUND(HttpStatus.BAD_REQUEST, "AREA_002", "해당 지역 정보가 존재하지 않습니다.");
 
   private final HttpStatus status;
   private final String code;

--- a/src/main/java/region/jidogam/domain/area/exception/AreaNotFoundException.java
+++ b/src/main/java/region/jidogam/domain/area/exception/AreaNotFoundException.java
@@ -7,6 +7,6 @@ public class AreaNotFoundException extends AreaException {
   }
 
   public static AreaNotFoundException withSidoAndSigungu(String sido, String sigungu) {
-    return new AreaNotFoundException(sido + ", " + sigungu + " not found");
+    return new AreaNotFoundException(sido + ", " + sigungu + " 정보가 존재하지 않습니다.");
   }
 }

--- a/src/main/java/region/jidogam/domain/area/exception/AreaNotFoundException.java
+++ b/src/main/java/region/jidogam/domain/area/exception/AreaNotFoundException.java
@@ -1,0 +1,12 @@
+package region.jidogam.domain.area.exception;
+
+public class AreaNotFoundException extends AreaException {
+
+  public AreaNotFoundException(String message) {
+    super(AreaErrorCode.AREA_NOT_FOUND, message);
+  }
+
+  public static AreaNotFoundException withSidoAndSigungu(String sido, String sigungu) {
+    return new AreaNotFoundException(sido + ", " + sigungu + " not found");
+  }
+}

--- a/src/main/java/region/jidogam/domain/area/exception/UnknownSidoException.java
+++ b/src/main/java/region/jidogam/domain/area/exception/UnknownSidoException.java
@@ -7,6 +7,6 @@ public class UnknownSidoException extends AreaException {
   }
 
   public static UnknownSidoException withSido(String sido) {
-    return new UnknownSidoException("Unknown sido alias: " + sido);
+    return new UnknownSidoException("'" + sido + "'와 매칭되는 시도가 없습니다.");
   }
 }

--- a/src/main/java/region/jidogam/domain/area/repository/AreaRepository.java
+++ b/src/main/java/region/jidogam/domain/area/repository/AreaRepository.java
@@ -1,5 +1,6 @@
 package region.jidogam.domain.area.repository;
 
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import region.jidogam.domain.area.entity.Area;
@@ -7,4 +8,6 @@ import region.jidogam.domain.area.entity.Area;
 public interface AreaRepository extends JpaRepository<Area, UUID> {
 
   boolean existsBySigunguCode(String sigunguCode);
+
+  Optional<Area> findBySidoAndSigungu(String sido, String sigungu);
 }

--- a/src/main/java/region/jidogam/domain/area/service/AreaService.java
+++ b/src/main/java/region/jidogam/domain/area/service/AreaService.java
@@ -5,10 +5,12 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import region.jidogam.domain.area.dto.api.AddressInfo;
 import region.jidogam.domain.area.dto.api.Sido;
 import region.jidogam.domain.area.dto.api.Sigungu;
 import region.jidogam.domain.area.entity.Area;
-import region.jidogam.domain.area.external.AreaApiService;
+import region.jidogam.domain.area.exception.AreaNotFoundException;
+import region.jidogam.domain.area.parser.AddressParser;
 import region.jidogam.domain.area.repository.AreaRepository;
 
 @Slf4j
@@ -16,8 +18,8 @@ import region.jidogam.domain.area.repository.AreaRepository;
 @RequiredArgsConstructor
 public class AreaService {
 
-  private final AreaApiService areaApiService;
   private final AreaRepository areaRepository;
+  private final AddressParser addressParser;
 
   @Transactional
   public void saveAreaDate(Sido sido, List<Sigungu> sigungus) {
@@ -34,5 +36,17 @@ public class AreaService {
 
     areaRepository.saveAll(areas);
     log.info("{} 지역 시군구 저장 완료 (total: {})", sido.addressName(), sigungus.size());
+  }
+
+  // 캐시 필요
+  public Area getAreaByAddress(String fullAddress) {
+
+    AddressInfo addressInfo = addressParser.parseAddress(fullAddress);
+
+    String sido = addressInfo.sido();
+    String sigungu = addressInfo.sigungu();
+
+    return areaRepository.findBySidoAndSigungu(sido, sigungu)
+      .orElseThrow(() -> AreaNotFoundException.withSidoAndSigungu(sido, sigungu));
   }
 }

--- a/src/main/java/region/jidogam/domain/place/dto/PlaceCreateRequest.java
+++ b/src/main/java/region/jidogam/domain/place/dto/PlaceCreateRequest.java
@@ -1,0 +1,39 @@
+package region.jidogam.domain.place.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
+
+public record PlaceCreateRequest(
+
+  @Schema(description = "카카오 장소ID", example = "")
+  String id,
+
+  @Schema(description = "장소명", example = "임시마트")
+  @NotBlank(message = "장소명은 필수입니다.")
+  String placeName,
+
+  @Schema(description = "주소", example = "전북 익산시 망산길 11-17")
+  @NotBlank(message = "주소는 필수입니다.")
+  String addressName,
+
+  @Schema(description = "카테고리", example = "마트")
+  String category,
+
+  @Schema(description = "위도", example = "35.976749396987046")
+  @NotNull(message = "위도 값은 필수입니다.")
+  @DecimalMin(value = "-90.0", message = "유효한 위도 값이 아닙니다.")
+  @DecimalMax(value = "90.0", message = "유효한 위도 값이 아닙니다.")
+  BigDecimal y,
+
+  @Schema(description = "경도", example = "126.99599512792346")
+  @NotNull(message = "경도 값은 필수입니다.")
+  @DecimalMin(value = "-180.0", message = "유효한 경도 값이 아닙니다.")
+  @DecimalMax(value = "180.0", message = "유효한 경도 값이 아닙니다.")
+  BigDecimal x
+) {
+
+}

--- a/src/main/java/region/jidogam/domain/place/exception/PlaceErrorCode.java
+++ b/src/main/java/region/jidogam/domain/place/exception/PlaceErrorCode.java
@@ -1,0 +1,17 @@
+package region.jidogam.domain.place.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import region.jidogam.common.exception.ErrorCode;
+
+@Getter
+@RequiredArgsConstructor
+public enum PlaceErrorCode implements ErrorCode {
+
+  PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, "PLACE_001", "존재하지 않는 장소입니다.");
+
+  private final HttpStatus status;
+  private final String code;
+  private final String message;
+}

--- a/src/main/java/region/jidogam/domain/place/exception/PlaceException.java
+++ b/src/main/java/region/jidogam/domain/place/exception/PlaceException.java
@@ -1,0 +1,11 @@
+package region.jidogam.domain.place.exception;
+
+import region.jidogam.common.exception.ErrorCode;
+import region.jidogam.common.exception.JidogamException;
+
+public class PlaceException extends JidogamException {
+
+  public PlaceException(ErrorCode errorCode, String message) {
+    super(errorCode, message);
+  }
+}

--- a/src/main/java/region/jidogam/domain/place/exception/PlaceNotFoundException.java
+++ b/src/main/java/region/jidogam/domain/place/exception/PlaceNotFoundException.java
@@ -1,0 +1,12 @@
+package region.jidogam.domain.place.exception;
+
+public class PlaceNotFoundException extends PlaceException {
+
+  public PlaceNotFoundException(String message) {
+    super(PlaceErrorCode.PLACE_NOT_FOUND, message);
+  }
+
+  public static PlaceNotFoundException withPlaceName(String name) {
+    return new PlaceNotFoundException("'" + name + "' 장소는 존재하지 않습니다.");
+  }
+}

--- a/src/main/java/region/jidogam/domain/place/repository/PlaceRepository.java
+++ b/src/main/java/region/jidogam/domain/place/repository/PlaceRepository.java
@@ -1,0 +1,9 @@
+package region.jidogam.domain.place.repository;
+
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import region.jidogam.domain.place.entity.Place;
+
+public interface PlaceRepository extends JpaRepository<Place, UUID> {
+
+}

--- a/src/main/java/region/jidogam/domain/place/service/PlaceService.java
+++ b/src/main/java/region/jidogam/domain/place/service/PlaceService.java
@@ -1,6 +1,7 @@
 package region.jidogam.domain.place.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import region.jidogam.domain.area.entity.Area;
@@ -9,6 +10,7 @@ import region.jidogam.domain.place.dto.PlaceCreateRequest;
 import region.jidogam.domain.place.entity.Place;
 import region.jidogam.domain.place.repository.PlaceRepository;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class PlaceService {
@@ -19,6 +21,7 @@ public class PlaceService {
   // 내부 서비스용
   @Transactional
   public Place createPlace(PlaceCreateRequest request) {
+    log.info("장소 생성 시작: placeName = {}", request.placeName());
 
     // 1. area 정보 조회
     Area area = areaService.getAreaByAddress(request.addressName());
@@ -37,6 +40,7 @@ public class PlaceService {
       .points(points)
       .build();
 
+    log.info("장소 생성 완료: placeName = {}", request.placeName());
     return placeRepository.save(place);
   }
 

--- a/src/main/java/region/jidogam/domain/place/service/PlaceService.java
+++ b/src/main/java/region/jidogam/domain/place/service/PlaceService.java
@@ -1,0 +1,46 @@
+package region.jidogam.domain.place.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import region.jidogam.domain.area.entity.Area;
+import region.jidogam.domain.area.service.AreaService;
+import region.jidogam.domain.place.dto.PlaceCreateRequest;
+import region.jidogam.domain.place.entity.Place;
+import region.jidogam.domain.place.repository.PlaceRepository;
+
+@Service
+@RequiredArgsConstructor
+public class PlaceService {
+
+  private final PlaceRepository placeRepository;
+  private final AreaService areaService;
+
+  // 내부 서비스용
+  @Transactional
+  public Place createPlace(PlaceCreateRequest request) {
+
+    // 1. area 정보 조회
+    Area area = areaService.getAreaByAddress(request.addressName());
+
+    // 2. 장소 포인트 설정
+    int points = calculatePoint(area.getWeight());
+
+    // 3. 장소 생성
+    Place place = Place.builder()
+      .name(request.placeName())
+      .address(request.addressName())
+      .x(request.x())
+      .y(request.y())
+      .category(request.category())
+      .area(area)
+      .points(points)
+      .build();
+
+    return placeRepository.save(place);
+  }
+
+  private int calculatePoint(Integer weight) {
+    return weight * 10; // 임시
+  }
+}

--- a/src/main/java/region/jidogam/domain/stamp/Repository/StampRepository.java
+++ b/src/main/java/region/jidogam/domain/stamp/Repository/StampRepository.java
@@ -1,0 +1,15 @@
+package region.jidogam.domain.stamp.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import region.jidogam.domain.stamp.entity.Stamp;
+
+public interface StampRepository extends JpaRepository<Stamp, UUID> {
+
+  // 유저의 마지막 도장 조회
+  Optional<Stamp> findFirstByUser_IdOrderByCreatedAtDesc(UUID uuid);
+
+  // 해당 장소에 도장을 찍었는지 확인
+  boolean existsByUser_IdAndPlace_Id(UUID userId, UUID placeId);
+}

--- a/src/main/java/region/jidogam/domain/stamp/controller/StampController.java
+++ b/src/main/java/region/jidogam/domain/stamp/controller/StampController.java
@@ -1,0 +1,30 @@
+package region.jidogam.domain.stamp.controller;
+
+import jakarta.validation.Valid;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import region.jidogam.domain.stamp.dto.PlaceStampRequest;
+import region.jidogam.domain.stamp.service.StampService;
+
+@RestController
+@RequestMapping("/api/stamp")
+@RequiredArgsConstructor
+public class StampController {
+
+  private final StampService stampService;
+
+  @PostMapping
+  public ResponseEntity<Void> stampPlace(
+    @Valid @RequestBody PlaceStampRequest request,
+    @RequestParam(name = "userId") UUID userId // 임시
+  ) {
+    stampService.stampPlace(request, userId);
+    return ResponseEntity.ok().build();
+  }
+}

--- a/src/main/java/region/jidogam/domain/stamp/dto/PlaceStampRequest.java
+++ b/src/main/java/region/jidogam/domain/stamp/dto/PlaceStampRequest.java
@@ -1,0 +1,19 @@
+package region.jidogam.domain.stamp.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import java.util.UUID;
+import region.jidogam.domain.place.dto.PlaceCreateRequest;
+
+public record PlaceStampRequest(
+
+  @Schema(description = "장소ID", example = "uuid-id")
+  UUID pid,
+
+  @Schema(description = "장소데이터")
+  @Valid
+  PlaceCreateRequest place
+
+) {
+
+}

--- a/src/main/java/region/jidogam/domain/stamp/exception/StampCooldownException.java
+++ b/src/main/java/region/jidogam/domain/stamp/exception/StampCooldownException.java
@@ -1,0 +1,12 @@
+package region.jidogam.domain.stamp.exception;
+
+public class StampCooldownException extends StampException {
+
+  public StampCooldownException(String message) {
+    super(StampErrorCode.STAMP_COOLDOWN_ACTIVE, message);
+  }
+
+  public static StampCooldownException withRestTime(Long minute) {
+    return new StampCooldownException("아직 도장을 찍을 수 없습니다. 최소 " + minute + "분 간격이 필요합니다.");
+  }
+}

--- a/src/main/java/region/jidogam/domain/stamp/exception/StampDuplicateException.java
+++ b/src/main/java/region/jidogam/domain/stamp/exception/StampDuplicateException.java
@@ -1,0 +1,12 @@
+package region.jidogam.domain.stamp.exception;
+
+public class StampDuplicateException extends StampException {
+
+  public StampDuplicateException(String message) {
+    super(StampErrorCode.STAMP_ALREADY_EXISTS, message);
+  }
+
+  public static StampDuplicateException withPlaceName(String placeName) {
+    return new StampDuplicateException("'" + placeName + "' 장소에 이미 도장이 있습니다.");
+  }
+}

--- a/src/main/java/region/jidogam/domain/stamp/exception/StampErrorCode.java
+++ b/src/main/java/region/jidogam/domain/stamp/exception/StampErrorCode.java
@@ -1,0 +1,18 @@
+package region.jidogam.domain.stamp.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import region.jidogam.common.exception.ErrorCode;
+
+@Getter
+@RequiredArgsConstructor
+public enum StampErrorCode implements ErrorCode {
+
+  STAMP_COOLDOWN_ACTIVE(HttpStatus.BAD_REQUEST, "STAMP_001", "도장은 연속으로 찍을 수 없습니다."),
+  STAMP_ALREADY_EXISTS(HttpStatus.CONFLICT, "STAMP_002", "이미 도장을 찍은 장소입니다.");
+
+  private final HttpStatus status;
+  private final String code;
+  private final String message;
+}

--- a/src/main/java/region/jidogam/domain/stamp/exception/StampException.java
+++ b/src/main/java/region/jidogam/domain/stamp/exception/StampException.java
@@ -1,0 +1,11 @@
+package region.jidogam.domain.stamp.exception;
+
+import region.jidogam.common.exception.ErrorCode;
+import region.jidogam.common.exception.JidogamException;
+
+public class StampException extends JidogamException {
+
+  public StampException(ErrorCode errorCode, String message) {
+    super(errorCode, message);
+  }
+}

--- a/src/main/java/region/jidogam/domain/stamp/service/StampService.java
+++ b/src/main/java/region/jidogam/domain/stamp/service/StampService.java
@@ -5,6 +5,7 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,6 +22,7 @@ import region.jidogam.domain.user.entity.User;
 import region.jidogam.domain.user.exception.UserNotFoundException;
 import region.jidogam.domain.user.repository.UserRepository;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class StampService {
@@ -36,6 +38,7 @@ public class StampService {
 
   @Transactional
   public void stampPlace(PlaceStampRequest request, UUID userId) {
+    log.info("장소 도장 찍기 시작: placeName = {}, userId = {}", request.place().placeName(), userId);
 
     // 1. 유저 확인
     User user = userRepository.findById(userId)
@@ -59,6 +62,8 @@ public class StampService {
       .build();
 
     stampRepository.save(stamp);
+    log.info("장소 도장 찍기 완료: placeName = {}, email = {}", request.place().placeName(),
+      user.getEmail());
   }
 
   // 기존 장소

--- a/src/main/java/region/jidogam/domain/stamp/service/StampService.java
+++ b/src/main/java/region/jidogam/domain/stamp/service/StampService.java
@@ -48,12 +48,7 @@ public class StampService {
     validateStampCoolTime(user.getId());
 
     // 3. 장소 데이터 조회
-    Place place;
-    if (request.pid() != null) {
-      place = handleExistingPlace(user, request);
-    } else {
-      place = handleNewPlace(request);
-    }
+    Place place = getOrCreatePlace(user, request);
 
     // 4. 도장
     Stamp stamp = Stamp.builder()
@@ -66,14 +61,18 @@ public class StampService {
       user.getEmail());
   }
 
+  private Place getOrCreatePlace(User user, PlaceStampRequest request) {
+    if (request.pid() != null) {
+      return handleExistingPlace(user, request);
+    }
+    return handleNewPlace(request);
+  }
+
   // 기존 장소
   private Place handleExistingPlace(User user, PlaceStampRequest request) {
     Place place = placeRepository.findById(request.pid())
       .orElseThrow(() -> PlaceNotFoundException.withPlaceName(request.place().placeName()));
-
-    // 도장 중복 검사
     validateDuplicateStamp(user, place);
-
     return place;
   }
 

--- a/src/main/java/region/jidogam/domain/stamp/service/StampService.java
+++ b/src/main/java/region/jidogam/domain/stamp/service/StampService.java
@@ -1,0 +1,97 @@
+package region.jidogam.domain.stamp.service;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import region.jidogam.domain.place.entity.Place;
+import region.jidogam.domain.place.exception.PlaceNotFoundException;
+import region.jidogam.domain.place.repository.PlaceRepository;
+import region.jidogam.domain.place.service.PlaceService;
+import region.jidogam.domain.stamp.Repository.StampRepository;
+import region.jidogam.domain.stamp.dto.PlaceStampRequest;
+import region.jidogam.domain.stamp.entity.Stamp;
+import region.jidogam.domain.stamp.exception.StampCooldownException;
+import region.jidogam.domain.stamp.exception.StampDuplicateException;
+import region.jidogam.domain.user.entity.User;
+import region.jidogam.domain.user.exception.UserNotFoundException;
+import region.jidogam.domain.user.repository.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+public class StampService {
+
+  @Value("${jidogam.stamp.cooldown.time}")
+  private Duration cooldownTime;
+
+  private final Clock clock;
+  private final UserRepository userRepository;
+  private final StampRepository stampRepository;
+  private final PlaceRepository placeRepository;
+  private final PlaceService placeService;
+
+  @Transactional
+  public void stampPlace(PlaceStampRequest request, UUID userId) {
+
+    // 1. 유저 확인
+    User user = userRepository.findById(userId)
+      .orElseThrow(() -> UserNotFoundException.withId(userId));
+
+    // 2. 유저의 마지막 도장 찍은 시간 조회 (유효 시간 외인 경우 예외)
+    validateStampCoolTime(user.getId());
+
+    // 3. 장소 데이터 조회
+    Place place;
+    if (request.pid() != null) {
+      place = handleExistingPlace(user, request);
+    } else {
+      place = handleNewPlace(request);
+    }
+
+    // 4. 도장
+    Stamp stamp = Stamp.builder()
+      .place(place)
+      .user(user)
+      .build();
+
+    stampRepository.save(stamp);
+  }
+
+  // 기존 장소
+  private Place handleExistingPlace(User user, PlaceStampRequest request) {
+    Place place = placeRepository.findById(request.pid())
+      .orElseThrow(() -> PlaceNotFoundException.withPlaceName(request.place().placeName()));
+
+    // 도장 중복 검사
+    validateDuplicateStamp(user, place);
+
+    return place;
+  }
+
+  // 새로운 장소
+  private Place handleNewPlace(PlaceStampRequest request) {
+    return placeService.createPlace(request.place());
+  }
+
+  // 도장 쿨타임 검사
+  private void validateStampCoolTime(UUID userId) {
+    LocalDateTime now = LocalDateTime.now(clock);
+    stampRepository.findFirstByUser_IdOrderByCreatedAtDesc(userId)
+      .ifPresent(lastStamp -> {
+        if (lastStamp.getCreatedAt().isAfter(now.minus(cooldownTime))) {
+          throw StampCooldownException.withRestTime(cooldownTime.toMinutes());
+        }
+      });
+  }
+
+  // 도장 중복 검사
+  private void validateDuplicateStamp(User user, Place place) {
+    if (stampRepository.existsByUser_IdAndPlace_Id(user.getId(), place.getId())) {
+      throw StampDuplicateException.withPlaceName(place.getName());
+    }
+  }
+}

--- a/src/main/java/region/jidogam/domain/user/exception/UserNotFoundException.java
+++ b/src/main/java/region/jidogam/domain/user/exception/UserNotFoundException.java
@@ -1,12 +1,14 @@
 package region.jidogam.domain.user.exception;
 
+import java.util.UUID;
+
 public class UserNotFoundException extends UserException {
 
   public UserNotFoundException(String message) {
     super(UserErrorCode.USER_NOT_FOUND, message);
   }
 
-  public static UserNotFoundException withId(String id) {
+  public static UserNotFoundException withId(UUID id) {
     return new UserNotFoundException(id + " not found");
   }
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -30,6 +30,9 @@ jidogam:
       region: ${AWS_S3_REGION}
       bucket: ${AWS_S3_BUCKET}
       presigned-url-expiration: ${AWS_S3_PRESIGNED_URL_EXPIRATION:600}
+  stamp:
+    cooldown:
+      time: ${STAMP_COOLDOWN_TIME:5m}
 
 jwt:
   secret: ${JWT_SECRET}

--- a/src/test/java/region/jidogam/domain/place/service/PlaceServiceTest.java
+++ b/src/test/java/region/jidogam/domain/place/service/PlaceServiceTest.java
@@ -1,0 +1,73 @@
+package region.jidogam.domain.place.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import region.jidogam.domain.area.entity.Area;
+import region.jidogam.domain.area.service.AreaService;
+import region.jidogam.domain.place.dto.PlaceCreateRequest;
+import region.jidogam.domain.place.entity.Place;
+import region.jidogam.domain.place.repository.PlaceRepository;
+
+@ExtendWith(MockitoExtension.class)
+class PlaceServiceTest {
+
+  @Mock
+  private PlaceRepository placeRepository;
+
+  @Mock
+  private AreaService areaService;
+
+  @InjectMocks
+  private PlaceService placeService;
+
+  @Test
+  @DisplayName("장소 생성 성공")
+  void createPlaceSuccess() {
+    // given
+    Area area = Area.builder()
+      .sigunguCode("1234")
+      .sido("전라북도특별자치도")
+      .sigungu("익산시")
+      .weight(1)
+      .build();
+
+    PlaceCreateRequest request = new PlaceCreateRequest(
+      null,
+      "임시마트",
+      "전북 익산시 망산길 11-17",
+      null,
+      BigDecimal.valueOf(35.976749396987046),
+      BigDecimal.valueOf(126.99599512792346)
+    );
+
+    Place place = Place.builder()
+      .name(request.placeName())
+      .address(request.addressName())
+      .x(request.x())
+      .y(request.y())
+      .category(request.category())
+      .area(area)
+      .points(10)
+      .build();
+
+    when(areaService.getAreaByAddress(any(String.class))).thenReturn(area);
+    when(placeRepository.save(any(Place.class))).thenReturn(place);
+
+    // when
+    Place newPlace = placeService.createPlace(request);
+
+    // then
+    assertThat(newPlace.getName()).isEqualTo("임시마트");
+    assertThat(newPlace.getAddress()).isEqualTo(request.addressName());
+
+  }
+}

--- a/src/test/java/region/jidogam/domain/stamp/service/StampServiceTest.java
+++ b/src/test/java/region/jidogam/domain/stamp/service/StampServiceTest.java
@@ -1,0 +1,261 @@
+package region.jidogam.domain.stamp.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import region.jidogam.domain.area.entity.Area;
+import region.jidogam.domain.place.dto.PlaceCreateRequest;
+import region.jidogam.domain.place.entity.Place;
+import region.jidogam.domain.place.exception.PlaceNotFoundException;
+import region.jidogam.domain.place.repository.PlaceRepository;
+import region.jidogam.domain.place.service.PlaceService;
+import region.jidogam.domain.stamp.Repository.StampRepository;
+import region.jidogam.domain.stamp.dto.PlaceStampRequest;
+import region.jidogam.domain.stamp.entity.Stamp;
+import region.jidogam.domain.stamp.exception.StampCooldownException;
+import region.jidogam.domain.stamp.exception.StampDuplicateException;
+import region.jidogam.domain.user.entity.User;
+import region.jidogam.domain.user.repository.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+class StampServiceTest {
+
+  @Mock
+  private UserRepository userRepository;
+
+  @Mock
+  private StampRepository stampRepository;
+
+  @Mock
+  private PlaceRepository placeRepository;
+
+  @Mock
+  private PlaceService placeService;
+
+  @Mock
+  private Clock clock;
+
+  @InjectMocks
+  private StampService stampService;
+
+  private UUID userId;
+  private User user;
+  private UUID placeId;
+  private Place place;
+  private PlaceCreateRequest placeCreateRequest;
+  private Area area;
+
+  @BeforeEach
+  void setUp() {
+    // 테스트 쿨타임 5분
+    ReflectionTestUtils.setField(stampService, "cooldownTime", Duration.ofMinutes(5));
+
+    ZoneId zone = ZoneId.of("Asia/Seoul");
+    Instant fixed = LocalDateTime.of(2025, 8, 20, 12, 0).atZone(zone).toInstant();
+    when(clock.instant()).thenReturn(fixed);
+    when(clock.getZone()).thenReturn(zone);
+
+    userId = UUID.randomUUID();
+    placeId = UUID.randomUUID();
+
+    user = User.builder()
+      .email("user@email.com")
+      .nickname("users")
+      .exp(0L)
+      .password("testPassword")
+      .profileImageUrl(null)
+      .build();
+
+    placeCreateRequest = new PlaceCreateRequest(
+      null,
+      "임시마트",
+      "전북 익산시 망산길 11-17",
+      null,
+      BigDecimal.valueOf(35.976749396987046),
+      BigDecimal.valueOf(126.99599512792346)
+    );
+
+    area = Area.builder()
+      .sigunguCode("1234")
+      .sido("전라북도특별자치도")
+      .sigungu("익산시")
+      .weight(1)
+      .build();
+
+    place = Place.builder()
+      .name(placeCreateRequest.placeName())
+      .address(placeCreateRequest.addressName())
+      .x(placeCreateRequest.x())
+      .y(placeCreateRequest.y())
+      .category(placeCreateRequest.category())
+      .area(area)
+      .points(10)
+      .build();
+  }
+
+  @Test
+  @DisplayName("이미 존재하는 장소인 경우 도장 찍기 성공")
+  void alreadyExistsPlaceStampSuccess() {
+    // given
+    when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+    when(stampRepository.findFirstByUser_IdOrderByCreatedAtDesc(user.getId()))
+      .thenReturn(Optional.empty());
+
+    UUID placeId = UUID.randomUUID();
+    when(placeRepository.findById(placeId)).thenReturn(Optional.of(place));
+    when(stampRepository.existsByUser_IdAndPlace_Id(user.getId(), place.getId()))
+      .thenReturn(false);
+
+    PlaceStampRequest request = new PlaceStampRequest(placeId, placeCreateRequest);
+
+    // when
+    stampService.stampPlace(request, userId);
+
+    // then
+    verify(placeService, never()).createPlace(request.place());
+
+    // save가 호출될 때 인자를 캡처, 캡처된 Stamp 객체의 내용을 검증
+    ArgumentCaptor<Stamp> stampCaptor = ArgumentCaptor.forClass(Stamp.class);
+    verify(stampRepository).save(stampCaptor.capture());
+
+    Stamp savedStamp = stampCaptor.getValue();
+    assertThat(savedStamp.getUser()).isEqualTo(user);
+    assertThat(savedStamp.getPlace()).isEqualTo(place);
+  }
+
+  @Test
+  @DisplayName("새로운 장소인 경우 도장 찍기 성공")
+  void newPlaceStampSuccess() {
+    // given
+    when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+    when(stampRepository.findFirstByUser_IdOrderByCreatedAtDesc(user.getId()))
+      .thenReturn(Optional.empty());
+    when(placeService.createPlace(placeCreateRequest)).thenReturn(place);
+
+    PlaceStampRequest request = new PlaceStampRequest(null, placeCreateRequest);
+
+    // when
+    stampService.stampPlace(request, userId);
+
+    // then
+    ArgumentCaptor<Stamp> stampCaptor = ArgumentCaptor.forClass(Stamp.class);
+    verify(stampRepository).save(stampCaptor.capture());
+
+    Stamp savedStamp = stampCaptor.getValue();
+    assertThat(savedStamp.getUser()).isEqualTo(user);
+    assertThat(savedStamp.getPlace()).isEqualTo(place);
+  }
+
+  @Test
+  @DisplayName("장소id로 장소 데이터를 찾을 수 없는 경우 실패")
+  void failsByPlaceNotFound() {
+    // given
+    when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+    when(stampRepository.findFirstByUser_IdOrderByCreatedAtDesc(user.getId()))
+      .thenReturn(Optional.empty());
+    when(placeRepository.findById(placeId)).thenReturn(Optional.empty());
+    PlaceStampRequest request = new PlaceStampRequest(placeId, placeCreateRequest);
+
+    // when & then
+    assertThrows(PlaceNotFoundException.class,
+      () -> stampService.stampPlace(request, userId));
+  }
+
+  @Test
+  @DisplayName("이미 도장을 찍은 장소일 경우 실패")
+  void failsByAlreadyStamp() {
+    // given
+    when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+    when(stampRepository.findFirstByUser_IdOrderByCreatedAtDesc(user.getId()))
+      .thenReturn(Optional.empty());
+    when(placeRepository.findById(placeId)).thenReturn(Optional.of(place));
+    when(stampRepository.existsByUser_IdAndPlace_Id(user.getId(), place.getId()))
+      .thenReturn(true);
+
+    PlaceStampRequest request = new PlaceStampRequest(placeId, placeCreateRequest);
+
+    // when & then
+    assertThrows(StampDuplicateException.class,
+      () -> stampService.stampPlace(request, userId));
+  }
+
+  @Nested
+  @DisplayName("도장 쿨타임")
+  class StampCoolDownTime {
+
+    @Test
+    @DisplayName("도장 쿨타임이 남은 경우 실패")
+    void failsByCooldownTime() {
+      // given
+      when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+      // CoolTime 5분, 마지막 도장 3분 전
+      LocalDateTime recent = LocalDateTime.of(2025, 8, 20, 11, 57);
+      Stamp stamp = Stamp.builder()
+        .user(user)
+        .place(place)
+        .build();
+      ReflectionTestUtils.setField(stamp, "createdAt", recent);
+      when(stampRepository.findFirstByUser_IdOrderByCreatedAtDesc(user.getId()))
+        .thenReturn(Optional.of(stamp));
+
+      PlaceStampRequest request = new PlaceStampRequest(null, placeCreateRequest);
+
+      // when & then
+      assertThrows(StampCooldownException.class, () -> stampService.stampPlace(request, userId));
+    }
+
+    @Test
+    @DisplayName("도장 쿨타임이 지난 경우 성공")
+    void cooldownTimeIsAfterNowSuccess() {
+      // given
+      when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+      // CoolTime 5분, 마지막 도장 10분 전
+      LocalDateTime recent = LocalDateTime.of(2025, 8, 20, 11, 50);
+      Stamp stamp = Stamp.builder()
+        .user(user)
+        .place(place)
+        .build();
+      ReflectionTestUtils.setField(stamp, "createdAt", recent);
+      when(stampRepository.findFirstByUser_IdOrderByCreatedAtDesc(user.getId()))
+        .thenReturn(Optional.of(stamp));
+
+      when(placeService.createPlace(placeCreateRequest)).thenReturn(place);
+
+      PlaceStampRequest request = new PlaceStampRequest(null, placeCreateRequest);
+
+      // when
+      stampService.stampPlace(request, userId);
+
+      // then
+      ArgumentCaptor<Stamp> stampCaptor = ArgumentCaptor.forClass(Stamp.class);
+      verify(stampRepository).save(stampCaptor.capture());
+
+      Stamp savedStamp = stampCaptor.getValue();
+      assertThat(savedStamp.getUser()).isEqualTo(user);
+      assertThat(savedStamp.getPlace()).isEqualTo(place);
+    }
+  }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

#28

## 📝 PR 유형

<!-- 해당하는 유형에 'x'로 체크해주세요. -->

- [x] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug Fix)
- [ ] 코드 개선 (Refactoring)
- [ ] 문서 작업 (Documentation)
- [ ] 환경 설정 (Configuration)
- [ ] 기타 (Other)

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요 (이미지 첨부 가능)

- 장소 도장 찍기 기능이 추가되었습니다.
   - 기존에 저장된 장소는 pid를 통해 조회 됩니다.
   - pid가 없는 경우, 새로운 장소 생성 후 도장이 생성됩니다.
   - 쿨타임이 돌기 전에는 도장을 연속해서 찍을 수 없습니다. 지금은 임의로 5분으로 설정되어있습니다.
   - 장소 포인트 로직도 임의로 설정하였습니다.

### 스크린샷 (선택)

- 200, 정상적으로 도장이 찍혀짐

  <img width="903" height="519" alt="image" src="https://github.com/user-attachments/assets/a54e2a47-3fc9-43e5-a61e-2bd6bbfd4bdc" />


<br>


- 400, 쿨타임이 도는 경우

  <img width="893" height="558" alt="image" src="https://github.com/user-attachments/assets/184dd742-2232-4def-ac04-4c309150ddb3" />


<br>


- 409, 이미 도장이 있는 장소인 경우

  <img width="890" height="558" alt="image" src="https://github.com/user-attachments/assets/f787b936-efc9-485b-a8f1-276f48567919" />


<br>


- 404, pid에 맞는 데이터가 없는 경우

  <img width="879" height="565" alt="image" src="https://github.com/user-attachments/assets/1433a0ae-33d1-4389-ada5-10e9d5b29f1a" />



## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

- 편리성을 위해 UserNotFoundException에서 userId 타입이 String -> UUID로 변경되었습니다.

- 현재 pid에 맞는 데이터가 없는 경우, 404로 예외를 반환하고 있습니다.
  도장 찍기를 요청할때 장소 데이터도 함께 들어오기 때문에 not found인 경우에는 새로운 장소 데이터를 생성하여 연결할지가 고민되네요. 프론트와 데이터가 맞지 않는 상태라면 404를 반환하는게 맞는 것 같기도 합니다.

- 쿨타임 테스트를 하면서 Clock을 써보았는데요. 저렇게 쓰는게 맞는지 모르겠네요 ㅎㅎ..

## #️⃣닫을 이슈

<!-- 닫을 이슈 번호를 입력해주세요. -->

close #28