### PR TITLE
feat: 회원가입 시 리프레시 토큰 쿠키 설정 추가

### DIFF
--- a/src/main/java/region/jidogam/domain/user/controller/UserController.java
+++ b/src/main/java/region/jidogam/domain/user/controller/UserController.java
@@ -1,8 +1,10 @@
 package region.jidogam.domain.user.controller;
 
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -26,10 +28,13 @@ public class UserController {
   private final CookieUtil cookieUtil;
 
   @PostMapping
-  public ResponseEntity<?> register(@RequestBody @Valid UserCreateRequest request) {
+  public ResponseEntity<?> register(@RequestBody @Valid UserCreateRequest request,
+      HttpServletResponse response) {
 
     TokenPair tokenPair = userService.create(request);
-    cookieUtil.createRefreshTokenCookie(tokenPair.refreshToken());
+    ResponseCookie refreshTokenCookie = cookieUtil.createRefreshTokenCookie(
+        tokenPair.refreshToken());
+    response.addHeader("Set-Cookie", refreshTokenCookie.toString());
 
     return ResponseEntity.status(HttpStatus.CREATED)
         .body(ResponseDto.ok(new TokenResponse(tokenPair.accessToken())));


### PR DESCRIPTION
- 회원가입 시 생성된 리프레시 토큰을 Set-Cookie 헤더를 통해 응답에 포함하도록 수정

## #️⃣연관된 이슈

- #38 

## 📝 PR 유형

<!-- 해당하는 유형에 'x'로 체크해주세요. -->

- [ ] 기능 추가 (Feature)
- [x] 버그 수정 (Bug Fix)
- [ ] 코드 개선 (Refactoring)
- [ ] 문서 작업 (Documentation)
- [ ] 환경 설정 (Configuration)
- [ ] 기타 (Other)

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요 (이미지 첨부 가능)

- 회원가입 후 refreshToken을 쿠키로 반환하지 않는 오류 수정

### 스크린샷 (선택)
<img width="1052" height="505" alt="image" src="https://github.com/user-attachments/assets/1a544b79-bd57-469e-8221-d64fabfee7cc" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## #️⃣닫을 이슈

<!-- 닫을 이슈 번호를 입력해주세요. -->

close #38 