### PR TITLE
feat: 이메일 인증 코드 발송 기능 구현

### DIFF
--- a/src/main/java/region/jidogam/domain/auth/entity/EmailAuthCode.java
+++ b/src/main/java/region/jidogam/domain/auth/entity/EmailAuthCode.java
@@ -1,0 +1,35 @@
+package region.jidogam.domain.auth.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import region.jidogam.common.entity.BaseEntity;
+
+@Entity
+@Table(name = "email_auth_codes")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class EmailAuthCode extends BaseEntity {
+
+  @Column(nullable = false, unique = true)
+  private String email;
+
+  @Column(nullable = false)
+  private String code;
+
+  @Column(nullable = false)
+  private LocalDateTime expiresAt;
+
+  @Column(nullable = false)
+  @Builder.Default
+  private Boolean used = false;
+
+}

--- a/src/main/java/region/jidogam/domain/auth/repository/EmailAuthCodeRepository.java
+++ b/src/main/java/region/jidogam/domain/auth/repository/EmailAuthCodeRepository.java
@@ -1,0 +1,11 @@
+package region.jidogam.domain.auth.repository;
+
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import region.jidogam.domain.auth.entity.EmailAuthCode;
+
+public interface EmailAuthCodeRepository extends JpaRepository<EmailAuthCode, UUID> {
+
+  Optional<EmailAuthCode> findByEmail(String email);
+}

--- a/src/main/java/region/jidogam/domain/auth/service/EmailAuthService.java
+++ b/src/main/java/region/jidogam/domain/auth/service/EmailAuthService.java
@@ -2,7 +2,6 @@ package region.jidogam.domain.auth.service;
 
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
-import jakarta.transaction.Transactional;
 import java.security.SecureRandom;
 import java.time.Duration;
 import java.time.LocalDateTime;
@@ -32,7 +31,6 @@ public class EmailAuthService {
 
   private static final String EMAIL_TEMPLATE_NAME = "auth-code-email-template.html";
 
-  @Transactional
   public void sendAuthCodeEmail(String email) {
     try {
       log.info("HTML 이메일 발송 시작 - 수신자: {}", email);
@@ -63,6 +61,7 @@ public class EmailAuthService {
 
       // 플레이스홀더 치환
       htmlContent = htmlContent.replace("{{AUTH_CODE}}", authCode);
+      htmlContent = htmlContent.replace("{{AUTH_CODE_EXPIRATION}}", expiration.toMinutes()+"");
 
       helper.setText(htmlContent, true);
 

--- a/src/main/java/region/jidogam/domain/auth/service/EmailAuthService.java
+++ b/src/main/java/region/jidogam/domain/auth/service/EmailAuthService.java
@@ -1,0 +1,82 @@
+package region.jidogam.domain.auth.service;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import jakarta.transaction.Transactional;
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import region.jidogam.domain.auth.entity.EmailAuthCode;
+import region.jidogam.domain.auth.repository.EmailAuthCodeRepository;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EmailAuthService {
+
+  private final JavaMailSender mailSender;
+  private final EmailAuthCodeRepository emailAuthCodeRepository;
+
+  @Value("${jidogam.email.auth.expiration}")
+  private Duration expiration;
+
+  private static final String EMAIL_TEMPLATE_NAME = "auth-code-email-template.html";
+
+  @Transactional
+  public void sendAuthCodeEmail(String email) {
+    try {
+      log.info("HTML 이메일 발송 시작 - 수신자: {}", email);
+
+      MimeMessage message = mailSender.createMimeMessage();
+      MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+
+      helper.setTo(email);
+      helper.setSubject("[지도감] 이메일 인증 번호");
+
+      // HTML 템플릿 읽기
+      String htmlContent = loadEmailTemplate(EMAIL_TEMPLATE_NAME);
+
+      // 랜덤한 6자리 숫자 생성
+      SecureRandom secureRandom = new SecureRandom();
+      String authCode = String.format("%06d", secureRandom.nextInt(1000000));
+
+      // email 및 인증 코드 저장
+      // 이미 발급한 경우 삭제 후 새 인증코드 저장
+      emailAuthCodeRepository.findByEmail(email).ifPresent(emailAuthCodeRepository::delete);
+      EmailAuthCode emailAuthCode = EmailAuthCode.builder()
+          .email(email)
+          .code(authCode)
+          .expiresAt(LocalDateTime.now().plus(expiration))
+          .build();
+
+      emailAuthCodeRepository.save(emailAuthCode);
+
+      // 플레이스홀더 치환
+      htmlContent = htmlContent.replace("{{AUTH_CODE}}", authCode);
+
+      helper.setText(htmlContent, true);
+
+      mailSender.send(message);
+      log.info("HTML 이메일 발송 완료 - 수신자: {}", email);
+
+    } catch (MessagingException | IOException e) {
+      log.error("이메일 발송 실패 - 수신자: {}, 에러: {}", email, e.getMessage());
+      throw new RuntimeException("이메일 발송에 실패했습니다.", e);
+    }
+  }
+
+  private String loadEmailTemplate(String templateName) throws IOException {
+    ClassPathResource resource = new ClassPathResource("templates/email/" + templateName);
+    return resource.getContentAsString(StandardCharsets.UTF_8);
+  }
+}

--- a/src/main/java/region/jidogam/domain/user/controller/UserController.java
+++ b/src/main/java/region/jidogam/domain/user/controller/UserController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import region.jidogam.common.dto.response.ResponseDto;
 import region.jidogam.common.util.CookieUtil;
+import region.jidogam.domain.auth.service.EmailAuthService;
 import region.jidogam.domain.jwt.dto.TokenPair;
 import region.jidogam.domain.jwt.dto.TokenResponse;
 import region.jidogam.domain.user.dto.UserCreateRequest;
@@ -23,6 +24,7 @@ import region.jidogam.domain.user.service.UserService;
 public class UserController {
 
   private final UserService userService;
+  private final EmailAuthService emailAuthService;
   private final CookieUtil cookieUtil;
 
   @PostMapping
@@ -45,5 +47,11 @@ public class UserController {
   public ResponseEntity<?> checkEmail(@RequestParam("email") String email) {
     userService.validateEmail(email);
     return ResponseEntity.ok((ResponseDto.ok("사용 가능한 이메일입니다.")));
+  }
+
+  @PostMapping("/auth-code")
+  public ResponseEntity<?> sendAuthCode(@RequestParam("email") String email) {
+    emailAuthService.sendAuthCodeEmail(email);
+    return ResponseEntity.ok().build();
   }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -18,6 +18,17 @@ spring:
       hibernate:
         highlight_sql: false
         format_sql: false
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
 
 jidogam:
   storage:
@@ -33,6 +44,9 @@ jidogam:
   stamp:
     cooldown:
       time: ${STAMP_COOLDOWN_TIME:5m}
+  email:
+    auth:
+      expiration: ${EMAIL_AUTH_CODE_EXPIRATION:5m}
 
 jwt:
   secret: ${JWT_SECRET}

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -107,6 +107,17 @@ CREATE TABLE refresh_tokens
     expires_at TIMESTAMP WITH TIME ZONE NOT NULL
 );
 
+-- Email auth code table
+CREATE TABLE email_auth_codes
+(
+    id UUID PRIMARY KEY,
+    email VARCHAR(50) NOT NULL UNIQUE,
+    code TEXT NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    expires_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    used BOOLEAN NOT NULL DEFAULT FALSE
+);
+
 -- Foreign Key Constraints
 ALTER TABLE places
     ADD CONSTRAINT fk_places_area_id

--- a/src/main/resources/templates/email/auth-code-email-template.html
+++ b/src/main/resources/templates/email/auth-code-email-template.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>지도감 이메일 인증</title>
+</head>
+<body style="font-family: Arial, sans-serif; margin: 0; padding: 20px; background-color: #f5f5f5;">
+
+<table width="100%" cellpadding="0" cellspacing="0" style="max-width: 600px; margin: 0 auto; background-color: white; border-radius: 8px;">
+
+  <!-- 헤더 -->
+  <tr>
+    <td style="background-color: #A2CD20; color: white; padding: 30px; text-align: center; border-radius: 8px 8px 0 0;">
+      <h1 style="margin: 0; font-size: 24px;">지도감</h1>
+      <p style="margin: 10px 0 0 0; font-size: 16px;">이메일 인증 번호</p>
+    </td>
+  </tr>
+
+  <!-- 본문 -->
+  <tr>
+    <td style="padding: 40px 30px;">
+      <h2 style="color: #333; margin-top: 0; text-align: center;">안녕하세요!</h2>
+      <p style="color: #666; font-size: 16px; line-height: 1.6; text-align: center;">
+        요청하신 이메일 인증 번호를 안내드립니다.<br>
+        아래 인증번호를 입력해주세요.
+      </p>
+
+      <!-- 인증번호 -->
+      <div style="background-color: #f8f9fa; border: 2px dashed #A2CD20; border-radius: 8px; padding: 20px; margin: 30px 0; text-align: center;">
+        <span style="font-size: 28px; font-weight: bold; color: #7ea310; letter-spacing: 2px;">{{AUTH_CODE}}</span>
+      </div>
+
+      <!-- 주의사항 -->
+      <div style="background-color: #fff3cd; border: 1px solid #ffeaa7; border-radius: 6px; padding: 15px; margin: 20px 0;">
+        <p style="margin: 0; color: #856404; font-size: 14px;">
+          <strong>⚠️ 중요:</strong> 이 인증번호는 30분 이내에만 유효합니다.<br>
+          로그인 후 반드시 비밀번호를 변경해주세요.
+        </p>
+      </div>
+
+      <p style="color: #666; font-size: 14px; text-align: center; margin-top: 30px;">
+        본인이 요청하지 않은 인증번호라면 이 이메일을 무시하셔도 됩니다.
+      </p>
+    </td>
+  </tr>
+
+  <!-- 푸터 -->
+  <tr>
+    <td style="background-color: #f8f9fa; padding: 20px; text-align: center; border-top: 1px solid #e9ecef; border-radius: 0 0 8px 8px;">
+      <p style="margin: 0; color: #6c757d; font-size: 12px;">
+        이 이메일은 자동으로 발송되었습니다. 회신하지 마세요.<br>
+        © 2025 지도감. All rights reserved.
+      </p>
+    </td>
+  </tr>
+
+</table>
+
+</body>
+</html>

--- a/src/main/resources/templates/email/auth-code-email-template.html
+++ b/src/main/resources/templates/email/auth-code-email-template.html
@@ -33,8 +33,7 @@
       <!-- 주의사항 -->
       <div style="background-color: #fff3cd; border: 1px solid #ffeaa7; border-radius: 6px; padding: 15px; margin: 20px 0;">
         <p style="margin: 0; color: #856404; font-size: 14px;">
-          <strong>⚠️ 중요:</strong> 이 인증번호는 30분 이내에만 유효합니다.<br>
-          로그인 후 반드시 비밀번호를 변경해주세요.
+          <strong>⚠️ 중요:</strong> 이 인증번호는 {{AUTH_CODE_EXPIRATION}}분 이내에만 유효합니다.<br>
         </p>
       </div>
 


### PR DESCRIPTION
## #️⃣연관된 이슈
- #43 

## 📝 PR 유형

<!-- 해당하는 유형에 'x'로 체크해주세요. -->

- [x] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug Fix)
- [ ] 코드 개선 (Refactoring)
- [ ] 문서 작업 (Documentation)
- [x] 환경 설정 (Configuration)
- [ ] 기타 (Other)

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요 (이미지 첨부 가능)
### 01. EmailAuthCode 엔티티 추가
- email_auth_codes 테이블 추가 (이메일, 코드, 만료시간, 사용여부 필드)

### 02. 이메일 인증 코드 발송 기능 구현
- EmailAuthService 구현
- SecureRandom으로 6자리 인증코드 생성
- Gmail SMTP로 HTML 이메일 발송
- 기본 5분 만료시간 설정

### 03. 인증번호 발송 이메일 내용 템플릿 추가
- 임시 HTML 이메일 템플릿 추가 (auth-code-email-template.html) 

### 04. application.yaml에 설정 추가 및 .env 수정 
- application.yaml에 Gmail SMTP 설정 추가
- 환경변수 MAIL_USERNAME, MAIL_PASSWORD, EMAIL_AUTH_CODE_EXPIRATION 추가

### 스크린샷 (선택)
<img width="1511" height="860" alt="image" src="https://github.com/user-attachments/assets/861d0e0d-db00-4bd3-a8ac-1fee523788b2" />



## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

- POST /api/users/check-email 로 요청을 보내는데, 현재 API 명세서에는 인증번호를 받으려는 email 주소를 파라미터로 받을지, body로 받을지 정해져 있지 않아 일단 파라미터로 받는 것으로 구현하였습니다. 따라서, 정기 회의 후에 데이터 받는 부분은 변경될 수 있습니다.

- EmailAuthCode는 email unique로 하였습니다. 만약 기존에 발송한 코드가 있다면, 삭제 후 재발급하는 형식으로 구현하였습니다. 

- 현재 동기 방식으로 구현되어있으나, 추후에 비동기 방식으로 리팩토링할 예정입니다. 

- 환경변수가 추가되었습니다! 노션에 업데이트 해두었습니다.  

## #️⃣닫을 이슈

<!-- 닫을 이슈 번호를 입력해주세요. -->

close #43 