### PR TITLE
feat: 이메일 인증 코드 검증 기능 구현

### DIFF
--- a/src/main/java/region/jidogam/common/config/PublicApiEndpoints.java
+++ b/src/main/java/region/jidogam/common/config/PublicApiEndpoints.java
@@ -16,6 +16,10 @@ public final class PublicApiEndpoints {
   public static final String CHECK_NICKNAME  = "/api/users/check-nickname";
   public static final String CHECK_EMAIL = "/api/users/check-email";
 
+  // 이메일 인증 번호 전송 및 검증 API
+  public static final String EMAIL_AUTH = "/api/users/auth-code";
+  public static final String EMAIL_AUTH_CHECK = "/api/users/check-code";
+
   // 공개 조회 API
   public static final String SWAGGER_UI = "/swagger-ui/**";
 
@@ -26,7 +30,9 @@ public final class PublicApiEndpoints {
     return new String[]{
         AUTH_LOGIN,
         AUTH_REFRESH,
-        USERS_CREATE
+        USERS_CREATE,
+        EMAIL_AUTH,
+        EMAIL_AUTH_CHECK
     };
   }
 

--- a/src/main/java/region/jidogam/domain/auth/entity/EmailAuthCode.java
+++ b/src/main/java/region/jidogam/domain/auth/entity/EmailAuthCode.java
@@ -32,4 +32,7 @@ public class EmailAuthCode extends BaseEntity {
   @Builder.Default
   private Boolean used = false;
 
+  public void use() {
+    this.used = true;
+  }
 }

--- a/src/main/java/region/jidogam/domain/auth/exception/AlreadyUsedAuthCodeException.java
+++ b/src/main/java/region/jidogam/domain/auth/exception/AlreadyUsedAuthCodeException.java
@@ -1,0 +1,12 @@
+package region.jidogam.domain.auth.exception;
+
+public class AlreadyUsedAuthCodeException extends EmailAuthException{
+
+  public AlreadyUsedAuthCodeException(String message) {
+    super(EmailAuthErrorCode.ALREADY_USED_AUTH_CODE, message);
+  }
+
+  public static AlreadyUsedAuthCodeException withCode(String code) {
+    return new AlreadyUsedAuthCodeException("'"+ code + "'은(는) 이미 사용된 인증 번호 입니다.");
+  }
+}

--- a/src/main/java/region/jidogam/domain/auth/exception/EmailAuthErrorCode.java
+++ b/src/main/java/region/jidogam/domain/auth/exception/EmailAuthErrorCode.java
@@ -1,0 +1,24 @@
+package region.jidogam.domain.auth.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import region.jidogam.common.exception.ErrorCode;
+
+@Getter
+public enum EmailAuthErrorCode implements ErrorCode {
+
+  INVALID_AUTH_CODE(HttpStatus.UNAUTHORIZED, "EMAILAUTH_001", "인증 코드가 일치하지 않습니다."),
+  EMAIL_AUTH_NOT_FOUND(HttpStatus.NOT_FOUND, "EMAILAUTH_002", "해당 이메일로 인증 번호가 발송된 이력이 없습니다." ),
+  EXPIRED_AUTH_CODE(HttpStatus.UNAUTHORIZED, "EMAILAUTH_003", "인증 시간이 만료된 인증 코드 입니다."),
+  ALREADY_USED_AUTH_CODE(HttpStatus.UNAUTHORIZED, "EMAILAUTH_004", "이미 사용된 인증 코드 입니다.");
+
+  private HttpStatus status;
+  private String code;
+  private final String message;
+
+  EmailAuthErrorCode(HttpStatus status , String code, String message) {
+    this.status = status;
+    this.code = code;
+    this.message = message;
+  }
+}

--- a/src/main/java/region/jidogam/domain/auth/exception/EmailAuthException.java
+++ b/src/main/java/region/jidogam/domain/auth/exception/EmailAuthException.java
@@ -1,0 +1,12 @@
+package region.jidogam.domain.auth.exception;
+
+import region.jidogam.common.exception.ErrorCode;
+import region.jidogam.common.exception.JidogamException;
+
+public class EmailAuthException extends JidogamException {
+
+  public EmailAuthException(ErrorCode errorCode, String message) {
+    super(errorCode, message);
+  }
+
+}

--- a/src/main/java/region/jidogam/domain/auth/exception/EmailAuthNotFoundException.java
+++ b/src/main/java/region/jidogam/domain/auth/exception/EmailAuthNotFoundException.java
@@ -1,0 +1,13 @@
+package region.jidogam.domain.auth.exception;
+
+
+public class EmailAuthNotFoundException extends EmailAuthException{
+
+  public EmailAuthNotFoundException(String message) {
+    super(EmailAuthErrorCode.EMAIL_AUTH_NOT_FOUND, message);
+  }
+
+  public static EmailAuthNotFoundException withEmail(String email) {
+    return new EmailAuthNotFoundException("'"+ email + "'로 발급한 인증 코드가 이미 만료되었거나 존재하지 않습니다.");
+  }
+}

--- a/src/main/java/region/jidogam/domain/auth/exception/ExpiredEmailAuthException.java
+++ b/src/main/java/region/jidogam/domain/auth/exception/ExpiredEmailAuthException.java
@@ -6,7 +6,7 @@ public class ExpiredEmailAuthException extends EmailAuthException{
     super(EmailAuthErrorCode.EXPIRED_AUTH_CODE, message);
   }
 
-  public static ExpiredEmailAuthException withEmail(String code) {
+  public static ExpiredEmailAuthException withCode(String code) {
     return new ExpiredEmailAuthException("'"+ code + "'은(는) 이미 만료된 인증번호 입니다.");
   }
 

--- a/src/main/java/region/jidogam/domain/auth/exception/ExpiredEmailAuthException.java
+++ b/src/main/java/region/jidogam/domain/auth/exception/ExpiredEmailAuthException.java
@@ -1,0 +1,13 @@
+package region.jidogam.domain.auth.exception;
+
+public class ExpiredEmailAuthException extends EmailAuthException{
+
+  public ExpiredEmailAuthException(String message) {
+    super(EmailAuthErrorCode.EXPIRED_AUTH_CODE, message);
+  }
+
+  public static ExpiredEmailAuthException withEmail(String code) {
+    return new ExpiredEmailAuthException("'"+ code + "'은(는) 이미 만료된 인증번호 입니다.");
+  }
+
+}

--- a/src/main/java/region/jidogam/domain/auth/exception/InvalidEmailAuthException.java
+++ b/src/main/java/region/jidogam/domain/auth/exception/InvalidEmailAuthException.java
@@ -1,0 +1,12 @@
+package region.jidogam.domain.auth.exception;
+
+public class InvalidEmailAuthException extends EmailAuthException{
+
+  public InvalidEmailAuthException(String message) {
+    super(EmailAuthErrorCode.INVALID_AUTH_CODE, message);
+  }
+
+  public static InvalidEmailAuthException withCode(String code) {
+    return new InvalidEmailAuthException("'"+ code + "'은(는) 유효하지 않은 이메일 인증 번호 입니다.");
+  }
+}

--- a/src/main/java/region/jidogam/domain/auth/service/EmailAuthService.java
+++ b/src/main/java/region/jidogam/domain/auth/service/EmailAuthService.java
@@ -1,81 +1,57 @@
 package region.jidogam.domain.auth.service;
 
-import jakarta.mail.MessagingException;
-import jakarta.mail.internet.MimeMessage;
 import java.security.SecureRandom;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.io.ClassPathResource;
-import org.springframework.mail.javamail.JavaMailSender;
-import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
 
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import region.jidogam.domain.auth.entity.EmailAuthCode;
+import region.jidogam.domain.auth.exception.AlreadyUsedAuthCodeException;
+import region.jidogam.domain.auth.exception.EmailAuthNotFoundException;
+import region.jidogam.domain.auth.exception.ExpiredEmailAuthException;
+import region.jidogam.domain.auth.exception.InvalidEmailAuthException;
 import region.jidogam.domain.auth.repository.EmailAuthCodeRepository;
+import region.jidogam.domain.user.dto.EmailAuthRequest;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class EmailAuthService {
 
-  private final JavaMailSender mailSender;
+  private final EmailService emailService;
   private final EmailAuthCodeRepository emailAuthCodeRepository;
 
   @Value("${jidogam.email.auth.expiration}")
   private Duration expiration;
 
-  private static final String EMAIL_TEMPLATE_NAME = "auth-code-email-template.html";
-
   public void sendAuthCodeEmail(String email) {
-    try {
-      log.info("HTML 이메일 발송 시작 - 수신자: {}", email);
-
-      MimeMessage message = mailSender.createMimeMessage();
-      MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
-
-      helper.setTo(email);
-      helper.setSubject("[지도감] 이메일 인증 번호");
-
-      // HTML 템플릿 읽기
-      String htmlContent = loadEmailTemplate(EMAIL_TEMPLATE_NAME);
-
-      // 랜덤한 6자리 숫자 생성
-      SecureRandom secureRandom = new SecureRandom();
-      String authCode = String.format("%06d", secureRandom.nextInt(1000000));
-
-      // email 및 인증 코드 저장
-      // 이미 발급한 경우 삭제 후 새 인증코드 저장
-      emailAuthCodeRepository.findByEmail(email).ifPresent(emailAuthCodeRepository::delete);
-      EmailAuthCode emailAuthCode = EmailAuthCode.builder()
-          .email(email)
-          .code(authCode)
-          .expiresAt(LocalDateTime.now().plus(expiration))
-          .build();
-
-      emailAuthCodeRepository.save(emailAuthCode);
-
-      // 플레이스홀더 치환
-      htmlContent = htmlContent.replace("{{AUTH_CODE}}", authCode);
-      htmlContent = htmlContent.replace("{{AUTH_CODE_EXPIRATION}}", expiration.toMinutes()+"");
-
-      helper.setText(htmlContent, true);
-
-      mailSender.send(message);
-      log.info("HTML 이메일 발송 완료 - 수신자: {}", email);
-
-    } catch (MessagingException | IOException e) {
-      log.error("이메일 발송 실패 - 수신자: {}, 에러: {}", email, e.getMessage());
-      throw new RuntimeException("이메일 발송에 실패했습니다.", e);
-    }
+    String authCode = createAuthCode(email);
+    //todo - 비동기 처리로 개선
+    emailService.sendAuthCodeEmail(email, authCode, expiration);
   }
 
-  private String loadEmailTemplate(String templateName) throws IOException {
-    ClassPathResource resource = new ClassPathResource("templates/email/" + templateName);
-    return resource.getContentAsString(StandardCharsets.UTF_8);
+  // 인증 코드 생성 및 저장
+  private String createAuthCode(String email) {
+    String authCode = generateAuthCode();
+
+    emailAuthCodeRepository.findByEmail(email)
+        .ifPresent(emailAuthCodeRepository::delete);
+
+    EmailAuthCode emailAuthCode = EmailAuthCode.builder()
+        .email(email)
+        .code(authCode)
+        .expiresAt(LocalDateTime.now().plus(expiration))
+        .build();
+
+    emailAuthCodeRepository.save(emailAuthCode);
+    return authCode;
+  }
+
+  private String generateAuthCode() {
+    SecureRandom secureRandom = new SecureRandom();
+    return String.format("%06d", secureRandom.nextInt(1000000));
   }
 }

--- a/src/main/java/region/jidogam/domain/auth/service/EmailAuthService.java
+++ b/src/main/java/region/jidogam/domain/auth/service/EmailAuthService.java
@@ -54,4 +54,39 @@ public class EmailAuthService {
     SecureRandom secureRandom = new SecureRandom();
     return String.format("%06d", secureRandom.nextInt(1000000));
   }
+
+  public void validateEmailAuthCode(EmailAuthRequest request) {
+    String email = request.email();
+    String authCode = request.authCode();
+
+    EmailAuthCode emailAuthCode = emailAuthCodeRepository.findByEmail(email)
+        .orElseThrow(() -> new EmailAuthNotFoundException(email));
+
+    validateAuthCode(emailAuthCode, authCode);
+    validateNotExpired(emailAuthCode, authCode);
+    validateNotUsed(emailAuthCode, authCode);
+
+    emailAuthCode.use();
+  }
+
+  //인증 코드 일치 여부 확인
+  private void validateAuthCode(EmailAuthCode emailAuthCode, String authCode) {
+    if (!emailAuthCode.getCode().equals(authCode)) {
+      throw new InvalidEmailAuthException(authCode);
+    }
+  }
+
+  //인증 코드 만료 여부 확인
+  private void validateNotExpired(EmailAuthCode emailAuthCode, String authCode) {
+    if (emailAuthCode.getExpiresAt().isBefore(LocalDateTime.now())) {
+      throw new ExpiredEmailAuthException(authCode);
+    }
+  }
+
+  //인증 코드 사용 여부 확인
+  private void validateNotUsed(EmailAuthCode emailAuthCode, String authCode) {
+    if (emailAuthCode.getUsed()) {
+      throw new AlreadyUsedAuthCodeException(authCode);
+    }
+  }
 }

--- a/src/main/java/region/jidogam/domain/auth/service/EmailService.java
+++ b/src/main/java/region/jidogam/domain/auth/service/EmailService.java
@@ -1,0 +1,68 @@
+package region.jidogam.domain.auth.service;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+
+  private final JavaMailSender mailSender;
+  private static final String EMAIL_TEMPLATE_NAME = "auth-code-email-template.html";
+
+  // 이메일 발송
+  public void sendAuthCodeEmail(String email, String authCode, Duration expiration) {
+    try {
+      log.info("HTML 이메일 발송 시작 - 수신자: {}", email);
+
+      MimeMessage message = createMimeMessage(email, authCode, expiration);
+      mailSender.send(message);
+
+      log.info("HTML 이메일 발송 완료 - 수신자: {}", email);
+    } catch (MessagingException | IOException e) {
+      log.error("이메일 발송 실패 - 수신자: {}, 에러: {}", email, e.getMessage());
+      throw new RuntimeException("이메일 발송에 실패했습니다.", e);
+    }
+  }
+
+  // MIME 메시지 생성
+  private MimeMessage createMimeMessage(String email, String authCode, Duration expiration)
+      throws MessagingException, IOException {
+
+    MimeMessage message = mailSender.createMimeMessage();
+    MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+
+    helper.setTo(email);
+    helper.setSubject("[지도감] 이메일 인증 번호");
+
+    String htmlContent = buildEmailContent(authCode, expiration);
+    helper.setText(htmlContent, true);
+
+    return message;
+  }
+
+  // 이메일 내용 구성
+  private String buildEmailContent(String authCode, Duration expiration) throws IOException {
+    String htmlContent = loadEmailTemplate(EMAIL_TEMPLATE_NAME);
+    htmlContent = htmlContent.replace("{{AUTH_CODE}}", authCode);
+    htmlContent = htmlContent.replace("{{AUTH_CODE_EXPIRATION}}",
+        expiration.toMinutes() + "");
+    return htmlContent;
+  }
+
+  // 이메일 내용 템플릿 불러오기
+  private String loadEmailTemplate(String templateName) throws IOException {
+    ClassPathResource resource = new ClassPathResource("templates/email/" + templateName);
+    return resource.getContentAsString(StandardCharsets.UTF_8);
+  }
+}

--- a/src/main/java/region/jidogam/domain/user/controller/UserController.java
+++ b/src/main/java/region/jidogam/domain/user/controller/UserController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import region.jidogam.common.dto.response.ResponseDto;
 import region.jidogam.common.util.CookieUtil;
-import region.jidogam.domain.auth.service.EmailAuthService;
+import region.jidogam.domain.user.service.EmailAuthService;
 import region.jidogam.domain.user.dto.EmailAuthRequest;
 import region.jidogam.infrastructure.jwt.dto.TokenPair;
 import region.jidogam.infrastructure.jwt.dto.TokenResponse;

--- a/src/main/java/region/jidogam/domain/user/controller/UserController.java
+++ b/src/main/java/region/jidogam/domain/user/controller/UserController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 import region.jidogam.common.dto.response.ResponseDto;
 import region.jidogam.common.util.CookieUtil;
 import region.jidogam.domain.auth.service.EmailAuthService;
+import region.jidogam.domain.user.dto.EmailAuthRequest;
 import region.jidogam.infrastructure.jwt.dto.TokenPair;
 import region.jidogam.infrastructure.jwt.dto.TokenResponse;
 import region.jidogam.domain.user.dto.UserCreateRequest;
@@ -57,6 +58,12 @@ public class UserController {
   @PostMapping("/auth-code")
   public ResponseEntity<?> sendAuthCode(@RequestParam("email") String email) {
     emailAuthService.sendAuthCodeEmail(email);
+    return ResponseEntity.ok().build();
+  }
+
+  @PostMapping("/check-code")
+  public ResponseEntity<?> checkAuthCode(@RequestBody @Valid EmailAuthRequest request) {
+    emailAuthService.validateEmailAuthCode(request);
     return ResponseEntity.ok().build();
   }
 }

--- a/src/main/java/region/jidogam/domain/user/dto/EmailAuthRequest.java
+++ b/src/main/java/region/jidogam/domain/user/dto/EmailAuthRequest.java
@@ -1,0 +1,8 @@
+package region.jidogam.domain.user.dto;
+
+public record EmailAuthRequest (
+    String email,
+    String authCode
+){
+
+}

--- a/src/main/java/region/jidogam/domain/user/service/EmailAuthService.java
+++ b/src/main/java/region/jidogam/domain/user/service/EmailAuthService.java
@@ -1,4 +1,4 @@
-package region.jidogam.domain.auth.service;
+package region.jidogam.domain.user.service;
 
 import java.security.SecureRandom;
 import java.time.Duration;

--- a/src/main/java/region/jidogam/domain/user/service/EmailAuthService.java
+++ b/src/main/java/region/jidogam/domain/user/service/EmailAuthService.java
@@ -34,6 +34,21 @@ public class EmailAuthService {
     emailService.sendAuthCodeEmail(email, authCode, expiration);
   }
 
+  @Transactional
+  public void validateEmailAuthCode(EmailAuthRequest request) {
+    String email = request.email();
+    String authCode = request.authCode();
+
+    EmailAuthCode emailAuthCode = emailAuthCodeRepository.findByEmail(email)
+        .orElseThrow(() -> new EmailAuthNotFoundException(email));
+
+    validateAuthCode(emailAuthCode, authCode);
+    validateNotExpired(emailAuthCode, authCode);
+    validateNotUsed(emailAuthCode, authCode);
+
+    emailAuthCode.use();
+  }
+
   // 인증 코드 생성 및 저장
   private String createAuthCode(String email) {
     String authCode = generateAuthCode();
@@ -54,21 +69,6 @@ public class EmailAuthService {
   private String generateAuthCode() {
     SecureRandom secureRandom = new SecureRandom();
     return String.format("%06d", secureRandom.nextInt(1000000));
-  }
-
-  @Transactional
-  public void validateEmailAuthCode(EmailAuthRequest request) {
-    String email = request.email();
-    String authCode = request.authCode();
-
-    EmailAuthCode emailAuthCode = emailAuthCodeRepository.findByEmail(email)
-        .orElseThrow(() -> new EmailAuthNotFoundException(email));
-
-    validateAuthCode(emailAuthCode, authCode);
-    validateNotExpired(emailAuthCode, authCode);
-    validateNotUsed(emailAuthCode, authCode);
-
-    emailAuthCode.use();
   }
 
   //인증 코드 일치 여부 확인

--- a/src/main/java/region/jidogam/domain/user/service/EmailAuthService.java
+++ b/src/main/java/region/jidogam/domain/user/service/EmailAuthService.java
@@ -8,6 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+import org.springframework.transaction.annotation.Transactional;
 import region.jidogam.domain.auth.entity.EmailAuthCode;
 import region.jidogam.domain.auth.exception.AlreadyUsedAuthCodeException;
 import region.jidogam.domain.auth.exception.EmailAuthNotFoundException;
@@ -55,6 +56,7 @@ public class EmailAuthService {
     return String.format("%06d", secureRandom.nextInt(1000000));
   }
 
+  @Transactional
   public void validateEmailAuthCode(EmailAuthRequest request) {
     String email = request.email();
     String authCode = request.authCode();
@@ -72,21 +74,21 @@ public class EmailAuthService {
   //인증 코드 일치 여부 확인
   private void validateAuthCode(EmailAuthCode emailAuthCode, String authCode) {
     if (!emailAuthCode.getCode().equals(authCode)) {
-      throw new InvalidEmailAuthException(authCode);
+      throw InvalidEmailAuthException.withCode(authCode);
     }
   }
 
   //인증 코드 만료 여부 확인
   private void validateNotExpired(EmailAuthCode emailAuthCode, String authCode) {
     if (emailAuthCode.getExpiresAt().isBefore(LocalDateTime.now())) {
-      throw new ExpiredEmailAuthException(authCode);
+      throw ExpiredEmailAuthException.withCode(authCode);
     }
   }
 
   //인증 코드 사용 여부 확인
   private void validateNotUsed(EmailAuthCode emailAuthCode, String authCode) {
     if (emailAuthCode.getUsed()) {
-      throw new AlreadyUsedAuthCodeException(authCode);
+      throw AlreadyUsedAuthCodeException.withCode(authCode);
     }
   }
 }

--- a/src/main/java/region/jidogam/domain/user/service/EmailService.java
+++ b/src/main/java/region/jidogam/domain/user/service/EmailService.java
@@ -1,4 +1,4 @@
-package region.jidogam.domain.auth.service;
+package region.jidogam.domain.user.service;
 
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;


### PR DESCRIPTION
## #️⃣연관된 이슈

- #48

## 📝 PR 유형

<!-- 해당하는 유형에 'x'로 체크해주세요. -->

- [x] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug Fix)
- [ ] 코드 개선 (Refactoring)
- [ ] 문서 작업 (Documentation)
- [ ] 환경 설정 (Configuration)
- [ ] 기타 (Other)

## 📝작업 내용

- **이메일 인증 엔드포인트 추가**:
  - 이메일 코드 전송 및 검증 엔드포인트를 구현했습니다.
  - `PublicApiEndpoints`를 업데이트하여 이를 공개 API로 노출했습니다.

- **이메일 인증 서비스 리팩토링**:
  - 더 나은 구조를 위해 `EmailAuthService`와 `EmailService`를 새로운 `user` 패키지로 이동했습니다.
  - 이메일 전송 로직을 `EmailService`로 분리했습니다.
  - 책임을 분리하여 코드 유지보수성과 확장성을 향상시켰습니다.

- **이메일 인증 기능 향상**:
  - 이메일 인증 코드 검증 로직을 추가했습니다 (예: 사용 여부, 만료, 유효성 확인).
  - 요청 데이터를 처리하기 위한 `EmailAuthRequest` DTO를 도입했습니다.
  - 데이터 무결성을 위한 트랜잭션 관리를 포함하도록 검증 로직을 업데이트했습니다.

- **이메일 인증 예외 처리 도입**:
  - `EmailAuthException`과 같은 적절한 예외 클래스를 추가했습니다.
  - 다양한 실패 시나리오에 대한 관련 오류 코드를 정의했습니다 (예: 유효하지 않음, 만료됨, 이미 사용된 코드).

### 스크린샷 
> 성공한 경우
<img width="1875" height="859" alt="image" src="https://github.com/user-attachments/assets/5a2d6cbe-d626-42f1-b1cf-ec72db5518d7" />
<br><br>

> 유효 시간 만료
<img width="1044" height="527" alt="image" src="https://github.com/user-attachments/assets/3ff5d2df-0a48-4aca-8062-7251d5cab7e0" />
<br><br>

> 유효하지 않은 인증번호
<img width="922" height="459" alt="image" src="https://github.com/user-attachments/assets/a72841cc-8563-4f98-8d0f-9810b6f20cf0" />
<br><br>

> 이미 인증에 사용한 인증번호
<img width="1871" height="644" alt="image" src="https://github.com/user-attachments/assets/ca6142d3-b4e5-47c5-a20b-f6b168ff558b" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## #️⃣닫을 이슈

<!-- 닫을 이슈 번호를 입력해주세요. -->

close #48 