### PR TITLE
test: 이메일 인증 코드 서비스 단위 테스트 코드 구현 및 리팩토링

### DIFF
--- a/src/main/java/region/jidogam/common/config/AsyncConfig.java
+++ b/src/main/java/region/jidogam/common/config/AsyncConfig.java
@@ -1,0 +1,10 @@
+package region.jidogam.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+}

--- a/src/main/java/region/jidogam/domain/user/event/EmailAuthCodeEventHandler.java
+++ b/src/main/java/region/jidogam/domain/user/event/EmailAuthCodeEventHandler.java
@@ -1,0 +1,39 @@
+package region.jidogam.domain.user.event;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+import region.jidogam.domain.user.service.EmailService;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class EmailAuthCodeEventHandler {
+
+  private final EmailService emailService;
+
+  @Async
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT) // 커밋 후 실행
+  public void handleEmailAuthCodeSend(EmailAuthCodeSendEvent event) {
+    try {
+      log.info("이메일 인증 코드 전송 시작: {}", event.email());
+      emailService.sendAuthCodeEmail(
+          event.email(),
+          event.authCode(),
+          event.expiration()
+      );
+      log.info("이메일 인증 코드 전송 완료: {}", event.email());
+    } catch (Exception e) {
+      log.error("이메일 전송 실패: {}", event.email(), e);
+      handleEmailSendFailure(event, e);
+    }
+  }
+
+  private void handleEmailSendFailure(EmailAuthCodeSendEvent event, Exception e) {
+    log.warn("이메일 전송 실패 후처리 - email: {}, error: {}", event.email(), e.getMessage());
+    // todo - 재시도나 알림 로직 추후 추가하기
+  }
+}

--- a/src/main/java/region/jidogam/domain/user/event/EmailAuthCodeSendEvent.java
+++ b/src/main/java/region/jidogam/domain/user/event/EmailAuthCodeSendEvent.java
@@ -1,0 +1,13 @@
+package region.jidogam.domain.user.event;
+
+import java.time.Duration;
+
+public record EmailAuthCodeSendEvent(
+    String email,
+    String authCode,
+    Duration expiration
+) {
+  public static EmailAuthCodeSendEvent of(String email, String authCode, Duration expiration) {
+    return new EmailAuthCodeSendEvent(email, authCode, expiration);
+  }
+}

--- a/src/main/java/region/jidogam/domain/user/provider/EmailAuthCodeProvider.java
+++ b/src/main/java/region/jidogam/domain/user/provider/EmailAuthCodeProvider.java
@@ -1,12 +1,7 @@
 package region.jidogam.domain.user.provider;
 
 import java.security.SecureRandom;
-import java.time.LocalDateTime;
 import org.springframework.stereotype.Component;
-import region.jidogam.domain.auth.entity.EmailAuthCode;
-import region.jidogam.domain.auth.exception.AlreadyUsedAuthCodeException;
-import region.jidogam.domain.auth.exception.ExpiredEmailAuthException;
-import region.jidogam.domain.auth.exception.InvalidEmailAuthException;
 
 @Component
 public class EmailAuthCodeProvider {
@@ -17,26 +12,5 @@ public class EmailAuthCodeProvider {
   public String generateAuthCode() {
     SecureRandom secureRandom = new SecureRandom();
     return String.format(AUTH_CODE_FORMAT, secureRandom.nextInt(AUTH_CODE_BOUND));
-  }
-
-  //인증 코드 일치 여부 확인
-  public void validateAuthCode(EmailAuthCode emailAuthCode, String authCode) {
-    if (!emailAuthCode.getCode().equals(authCode)) {
-      throw InvalidEmailAuthException.withCode(authCode);
-    }
-  }
-
-  //인증 코드 만료 여부 확인
-  public void validateNotExpired(EmailAuthCode emailAuthCode, String authCode) {
-    if (emailAuthCode.getExpiresAt().isBefore(LocalDateTime.now())) {
-      throw ExpiredEmailAuthException.withCode(authCode);
-    }
-  }
-
-  //인증 코드 사용 여부 확인
-  public void validateNotUsed(EmailAuthCode emailAuthCode, String authCode) {
-    if (emailAuthCode.getUsed()) {
-      throw AlreadyUsedAuthCodeException.withCode(authCode);
-    }
   }
 }

--- a/src/main/java/region/jidogam/domain/user/provider/EmailAuthCodeProvider.java
+++ b/src/main/java/region/jidogam/domain/user/provider/EmailAuthCodeProvider.java
@@ -1,0 +1,42 @@
+package region.jidogam.domain.user.provider;
+
+import java.security.SecureRandom;
+import java.time.LocalDateTime;
+import org.springframework.stereotype.Component;
+import region.jidogam.domain.auth.entity.EmailAuthCode;
+import region.jidogam.domain.auth.exception.AlreadyUsedAuthCodeException;
+import region.jidogam.domain.auth.exception.ExpiredEmailAuthException;
+import region.jidogam.domain.auth.exception.InvalidEmailAuthException;
+
+@Component
+public class EmailAuthCodeProvider {
+
+  private static final int AUTH_CODE_BOUND = 1_000_000;
+  private static final String AUTH_CODE_FORMAT = "%06d";
+
+  public String generateAuthCode() {
+    SecureRandom secureRandom = new SecureRandom();
+    return String.format(AUTH_CODE_FORMAT, secureRandom.nextInt(AUTH_CODE_BOUND));
+  }
+
+  //인증 코드 일치 여부 확인
+  public void validateAuthCode(EmailAuthCode emailAuthCode, String authCode) {
+    if (!emailAuthCode.getCode().equals(authCode)) {
+      throw InvalidEmailAuthException.withCode(authCode);
+    }
+  }
+
+  //인증 코드 만료 여부 확인
+  public void validateNotExpired(EmailAuthCode emailAuthCode, String authCode) {
+    if (emailAuthCode.getExpiresAt().isBefore(LocalDateTime.now())) {
+      throw ExpiredEmailAuthException.withCode(authCode);
+    }
+  }
+
+  //인증 코드 사용 여부 확인
+  public void validateNotUsed(EmailAuthCode emailAuthCode, String authCode) {
+    if (emailAuthCode.getUsed()) {
+      throw AlreadyUsedAuthCodeException.withCode(authCode);
+    }
+  }
+}

--- a/src/main/java/region/jidogam/domain/user/service/EmailAuthService.java
+++ b/src/main/java/region/jidogam/domain/user/service/EmailAuthService.java
@@ -6,6 +6,7 @@ import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 
 import org.springframework.transaction.annotation.Transactional;
@@ -16,42 +17,24 @@ import region.jidogam.domain.auth.exception.ExpiredEmailAuthException;
 import region.jidogam.domain.auth.exception.InvalidEmailAuthException;
 import region.jidogam.domain.auth.repository.EmailAuthCodeRepository;
 import region.jidogam.domain.user.dto.EmailAuthRequest;
+import region.jidogam.domain.user.event.EmailAuthCodeSendEvent;
+import region.jidogam.domain.user.provider.EmailAuthCodeProvider;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class EmailAuthService {
 
-  private final EmailService emailService;
+  private final EmailAuthCodeProvider emailAuthCodeProvider;
   private final EmailAuthCodeRepository emailAuthCodeRepository;
+  private final ApplicationEventPublisher eventPublisher;
 
   @Value("${jidogam.email.auth.expiration}")
   private Duration expiration;
 
-  public void sendAuthCodeEmail(String email) {
-    String authCode = createAuthCode(email);
-    //todo - 비동기 처리로 개선
-    emailService.sendAuthCodeEmail(email, authCode, expiration);
-  }
-
   @Transactional
-  public void validateEmailAuthCode(EmailAuthRequest request) {
-    String email = request.email();
-    String authCode = request.authCode();
-
-    EmailAuthCode emailAuthCode = emailAuthCodeRepository.findByEmail(email)
-        .orElseThrow(() -> new EmailAuthNotFoundException(email));
-
-    validateAuthCode(emailAuthCode, authCode);
-    validateNotExpired(emailAuthCode, authCode);
-    validateNotUsed(emailAuthCode, authCode);
-
-    emailAuthCode.use();
-  }
-
-  // 인증 코드 생성 및 저장
-  private String createAuthCode(String email) {
-    String authCode = generateAuthCode();
+  public void sendAuthCodeEmail(String email) {
+    String authCode = emailAuthCodeProvider.generateAuthCode();
 
     emailAuthCodeRepository.findByEmail(email)
         .ifPresent(emailAuthCodeRepository::delete);
@@ -63,32 +46,25 @@ public class EmailAuthService {
         .build();
 
     emailAuthCodeRepository.save(emailAuthCode);
-    return authCode;
+
+    eventPublisher.publishEvent(EmailAuthCodeSendEvent.of(email, authCode, expiration));
+    log.info("이메일 인증 코드 이벤트 발행 완료: {}", email);
   }
 
-  private String generateAuthCode() {
-    SecureRandom secureRandom = new SecureRandom();
-    return String.format("%06d", secureRandom.nextInt(1000000));
+  @Transactional
+  public void validateEmailAuthCode(EmailAuthRequest request) {
+    String email = request.email();
+    String authCode = request.authCode();
+
+    EmailAuthCode emailAuthCode = emailAuthCodeRepository.findByEmail(email)
+        .orElseThrow(() -> new EmailAuthNotFoundException(email));
+
+    emailAuthCodeProvider.validateAuthCode(emailAuthCode, authCode);
+    emailAuthCodeProvider.validateNotExpired(emailAuthCode, authCode);
+    emailAuthCodeProvider.validateNotUsed(emailAuthCode, authCode);
+
+    emailAuthCode.use();
   }
 
-  //인증 코드 일치 여부 확인
-  private void validateAuthCode(EmailAuthCode emailAuthCode, String authCode) {
-    if (!emailAuthCode.getCode().equals(authCode)) {
-      throw InvalidEmailAuthException.withCode(authCode);
-    }
-  }
 
-  //인증 코드 만료 여부 확인
-  private void validateNotExpired(EmailAuthCode emailAuthCode, String authCode) {
-    if (emailAuthCode.getExpiresAt().isBefore(LocalDateTime.now())) {
-      throw ExpiredEmailAuthException.withCode(authCode);
-    }
-  }
-
-  //인증 코드 사용 여부 확인
-  private void validateNotUsed(EmailAuthCode emailAuthCode, String authCode) {
-    if (emailAuthCode.getUsed()) {
-      throw AlreadyUsedAuthCodeException.withCode(authCode);
-    }
-  }
 }

--- a/src/main/java/region/jidogam/domain/user/service/EmailAuthService.java
+++ b/src/main/java/region/jidogam/domain/user/service/EmailAuthService.java
@@ -59,12 +59,15 @@ public class EmailAuthService {
     EmailAuthCode emailAuthCode = emailAuthCodeRepository.findByEmail(email)
         .orElseThrow(() -> new EmailAuthNotFoundException(email));
 
-    emailAuthCodeProvider.validateAuthCode(emailAuthCode, authCode);
-    emailAuthCodeProvider.validateNotExpired(emailAuthCode, authCode);
-    emailAuthCodeProvider.validateNotUsed(emailAuthCode, authCode);
-
+    if (!emailAuthCode.getCode().equals(authCode)) {
+      throw InvalidEmailAuthException.withCode(authCode);
+    }
+    if (emailAuthCode.getExpiresAt().isBefore(LocalDateTime.now())) {
+      throw ExpiredEmailAuthException.withCode(authCode);
+    }
+    if(emailAuthCode.getUsed()){
+      throw AlreadyUsedAuthCodeException.withCode(authCode);
+    }
     emailAuthCode.use();
   }
-
-
 }

--- a/src/test/java/region/jidogam/domain/user/service/EmailAuthServiceTest.java
+++ b/src/test/java/region/jidogam/domain/user/service/EmailAuthServiceTest.java
@@ -1,0 +1,216 @@
+package region.jidogam.domain.user.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.test.util.ReflectionTestUtils;
+import region.jidogam.domain.auth.entity.EmailAuthCode;
+import region.jidogam.domain.auth.exception.AlreadyUsedAuthCodeException;
+import region.jidogam.domain.auth.exception.EmailAuthNotFoundException;
+import region.jidogam.domain.auth.exception.ExpiredEmailAuthException;
+import region.jidogam.domain.auth.exception.InvalidEmailAuthException;
+import region.jidogam.domain.auth.repository.EmailAuthCodeRepository;
+import region.jidogam.domain.user.dto.EmailAuthRequest;
+import region.jidogam.domain.user.event.EmailAuthCodeSendEvent;
+import region.jidogam.domain.user.provider.EmailAuthCodeProvider;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("이메일 인증 서비스 단위테스트")
+public class EmailAuthServiceTest {
+
+  @Mock
+  private EmailAuthCodeProvider emailAuthCodeProvider;
+  @Mock
+  private EmailAuthCodeRepository emailAuthCodeRepository;
+  @Mock
+  private ApplicationEventPublisher eventPublisher;
+  @InjectMocks
+  private EmailAuthService emailAuthService;
+
+  @BeforeEach
+  void setUp() {
+    // Spring이 제공하는 ReflectionTestUtils 사용
+    ReflectionTestUtils.setField(emailAuthService, "expiration", Duration.ofMinutes(5));
+  }
+
+  @Nested
+  @DisplayName("이메일 인증 코드 전송")
+  class SendEmailAuthCodeTest {
+
+    @Test
+    @DisplayName("성공")
+    void success() {
+      //given
+      String email = "test@test.com";
+      String authCode = "1234";
+
+      when(emailAuthCodeProvider.generateAuthCode()).thenReturn(authCode);
+
+      when(emailAuthCodeRepository.findByEmail(email)).thenReturn(Optional.empty());
+
+      //when
+      emailAuthService.sendAuthCodeEmail(email);
+
+      //then
+      verify(eventPublisher, times(1)).publishEvent(any(EmailAuthCodeSendEvent.class));
+    }
+
+    @Test
+    @DisplayName("같은 이메일로 인증번호 재발급 성공")
+    void successWhenSameEmail() {
+      //given
+      String email = "test@test.com";
+      String authCode = "12345";
+
+      when(emailAuthCodeProvider.generateAuthCode()).thenReturn(authCode);
+
+      EmailAuthCode mockEmailAuthCode = EmailAuthCode.builder()
+          .email(email)
+          .code("12346")
+          .build();
+
+      when(emailAuthCodeRepository.findByEmail(email)).thenReturn(
+          Optional.ofNullable(mockEmailAuthCode));
+
+      //when
+      emailAuthService.sendAuthCodeEmail(email);
+
+      //then
+      verify(emailAuthCodeRepository, times(1)).delete(any(EmailAuthCode.class));
+      verify(eventPublisher, times(1)).publishEvent(any(EmailAuthCodeSendEvent.class));
+    }
+  }
+
+  @Nested
+  @DisplayName("이메일 인증 코드 검증")
+  class ValidateEmailAuthCodeTest {
+
+    @Test
+    @DisplayName("성공")
+    void success() {
+      //given
+      String email = "test@test.com";
+      String authCode = "12345";
+
+      EmailAuthCode mockEmailAuthCode = EmailAuthCode.builder()
+          .email(email)
+          .code(authCode)
+          .expiresAt(LocalDateTime.now().plus(Duration.ofMinutes(5)))
+          .build();
+
+      EmailAuthRequest emailAuthRequest = new EmailAuthRequest(email, authCode);
+
+      when(emailAuthCodeRepository.findByEmail(email)).thenReturn(
+          Optional.ofNullable(mockEmailAuthCode));
+
+      //when
+      emailAuthService.validateEmailAuthCode(emailAuthRequest);
+
+      //then
+      assertEquals(true, mockEmailAuthCode.getUsed());
+    }
+
+    @Test
+    @DisplayName("해당 이메일로 발급 이력이 없는 경우 실패")
+    void failsWhenEmailAuthCodeNotFound() {
+      //given
+      String email = "test@test.com";
+      String authCode = "12345";
+
+      EmailAuthRequest emailAuthRequest = new EmailAuthRequest(email, authCode);
+
+      when(emailAuthCodeRepository.findByEmail(email)).thenReturn(Optional.empty());
+
+      //when & then
+      assertThrows(EmailAuthNotFoundException.class,
+          () -> emailAuthService.validateEmailAuthCode(emailAuthRequest));
+    }
+
+    @Test
+    @DisplayName("인증 번호가 일치하지 않을 경우 실패")
+    void failsWhenAuthCodeNotMatch() {
+      //given
+      String email = "test@test.com";
+      String authCode = "12345";
+      String notMatchAuthCode = "12346";
+
+      EmailAuthCode mockEmailAuthCode = EmailAuthCode.builder()
+          .email(email)
+          .code(authCode)
+          .expiresAt(LocalDateTime.now().plus(Duration.ofMinutes(5)))
+          .build();
+
+      EmailAuthRequest emailAuthRequest = new EmailAuthRequest(email, notMatchAuthCode);
+
+      when(emailAuthCodeRepository.findByEmail(email)).thenReturn(
+          Optional.ofNullable(mockEmailAuthCode));
+
+      //when & then
+      assertThrows(InvalidEmailAuthException.class,
+          () -> emailAuthService.validateEmailAuthCode(emailAuthRequest));
+    }
+
+    @Test
+    @DisplayName("만료된 인증 코드일 경우")
+    void failsWhenAuthCodeExpired() {
+      //given
+      String email = "test@test.com";
+      String authCode = "12345";
+
+      EmailAuthCode mockEmailAuthCode = EmailAuthCode.builder()
+          .email(email)
+          .code(authCode)
+          .expiresAt(LocalDateTime.now().minus(Duration.ofMinutes(10)))
+          .build();
+
+      EmailAuthRequest emailAuthRequest = new EmailAuthRequest(email, authCode);
+
+      when(emailAuthCodeRepository.findByEmail(email)).thenReturn(
+          Optional.ofNullable(mockEmailAuthCode));
+
+      //when & then
+      assertThrows(ExpiredEmailAuthException.class,
+          () -> emailAuthService.validateEmailAuthCode(emailAuthRequest));
+    }
+
+    @Test
+    @DisplayName("이미 사용된 인증 번호인 경우")
+    void failsWhenAuthCodeAlreadyUsed() {
+      //given
+      String email = "test@test.com";
+      String authCode = "12345";
+
+      EmailAuthCode mockEmailAuthCode = EmailAuthCode.builder()
+          .email(email)
+          .code(authCode)
+          .expiresAt(LocalDateTime.now().plus(Duration.ofMinutes(5)))
+          .used(true)
+          .build();
+
+      EmailAuthRequest emailAuthRequest = new EmailAuthRequest(email, authCode);
+
+      when(emailAuthCodeRepository.findByEmail(email)).thenReturn(
+          Optional.ofNullable(mockEmailAuthCode));
+
+      //when & then
+      assertThrows(AlreadyUsedAuthCodeException.class,
+          () -> emailAuthService.validateEmailAuthCode(emailAuthRequest));
+    }
+  }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

- #51

## 📝 PR 유형

<!-- 해당하는 유형에 'x'로 체크해주세요. -->

- [ ] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug Fix)
- [x] 코드 개선 (Refactoring)
- [ ] 문서 작업 (Documentation)
- [ ] 환경 설정 (Configuration)
- [ ] 기타 (Other)

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요 (이미지 첨부 가능)

### 01. 이메일 인증 코드 발송 및 검증 서비스 단위테스트 코드 구현
- 이메일 인증 서비스에 대한 단위 테스트를 추가했습니다. (성공, 코드 불일치, 만료, 미사용, 재발급 등)

### 02. 이메일 인증 코드 발송 비동기 적용, 검증 서비스 리팩토링
- 이벤트 기반 비동기 방식을 사용하여 이메일 인증 코드 전송을 비동기로 처리하였습니다. 
   - 이를 통해 이메일 발송으로 인한 응답 대기시간을 단축하였습니다. ( 5.14s -> 194ms 로 단축 )
-`EmailAuthCodeProvider` 추가를 통해 코드 생성 로직을 분리하였습니다.


### 스크린샷 (선택)

> 동기, 인증번호 이메일 발송 응답 시간 ( 5.14 s )
<img width="1156" height="558" alt="image" src="https://github.com/user-attachments/assets/cd702ef4-fa9a-4dea-9ec0-46b787f9e286" />


> 비동기+이벤트, 인증번호 이메일 발송 응답 시간 ( 194ms )
<img width="1159" height="565" alt="image" src="https://github.com/user-attachments/assets/5020ba4b-314b-49d5-85d7-56ee1c936a0a" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

- 테스트 코드 작성하면서 private 메서드를 테스트해야한다는 것에서 뭔가 잘못되었음을 느껴 리팩토링을 같이 진행하였습니다. 이로인해 EmailAuthService가 많이 바뀌었습니다. 최대한 단일 책임 원칙에 부합하도록 수정하였는데 혹시 개선해야할 부분이 있다면 편하게 리뷰 남겨주시면 감사하겠습니다!

## #️⃣닫을 이슈

<!-- 닫을 이슈 번호를 입력해주세요. -->

close #51 