### PR TITLE
Add refresh token handling for access token renewal

### DIFF
--- a/src/main/java/region/jidogam/domain/auth/AuthController.java
+++ b/src/main/java/region/jidogam/domain/auth/AuthController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 import region.jidogam.common.dto.response.ResponseDto;
 import region.jidogam.common.util.CookieUtil;
 import region.jidogam.domain.auth.dto.LoginRequest;
+import region.jidogam.infrastructure.jwt.RefreshTokenService;
 import region.jidogam.infrastructure.jwt.dto.TokenPair;
 import region.jidogam.infrastructure.jwt.dto.TokenResponse;
 
@@ -24,6 +25,7 @@ public class AuthController {
 
   private final AuthService authService;
   private final CookieUtil cookieUtil;
+  private final RefreshTokenService refreshTokenService;
 
   @PostMapping("/login")
   public ResponseEntity<?> login(@RequestBody LoginRequest request, HttpServletResponse response)
@@ -48,5 +50,14 @@ public class AuthController {
     ResponseCookie refreshCookie = cookieUtil.deleteRefreshTokenCookie();
     response.addHeader("Set-Cookie", refreshCookie.toString());
     return ResponseEntity.noContent().build();
+  }
+
+  @PostMapping("/refresh")
+  public ResponseEntity<?> refresh(
+      @CookieValue(value = "refresh", required = false) String refreshToken)
+      throws AuthException {
+    String accessToken = refreshTokenService.refreshAccessToken(refreshToken);
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .body(ResponseDto.ok(new TokenResponse(accessToken)));
   }
 }

--- a/src/main/java/region/jidogam/domain/auth/AuthService.java
+++ b/src/main/java/region/jidogam/domain/auth/AuthService.java
@@ -1,12 +1,12 @@
 package region.jidogam.domain.auth;
 
 import jakarta.security.auth.message.AuthException;
-import jakarta.transaction.Transactional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import region.jidogam.domain.auth.dto.LoginRequest;
 import region.jidogam.domain.user.entity.User;
 import region.jidogam.domain.user.exception.UserNotFoundException;
@@ -59,5 +59,6 @@ public class AuthService {
         .orElseThrow(() -> UserNotFoundException.withId(userId));
 
     refreshTokenService.delete(user);
+    log.info("사용자 로그아웃 완료: id = {}", userId);
   }
 }

--- a/src/main/java/region/jidogam/infrastructure/jwt/RefreshTokenRepository.java
+++ b/src/main/java/region/jidogam/infrastructure/jwt/RefreshTokenRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, UUID> {
 
   Optional<RefreshToken> findByUserId(UUID userId);
+
+  Optional<RefreshToken> findByRefreshToken(String refreshToken);
 }

--- a/src/main/java/region/jidogam/infrastructure/jwt/RefreshTokenService.java
+++ b/src/main/java/region/jidogam/infrastructure/jwt/RefreshTokenService.java
@@ -1,12 +1,16 @@
 package region.jidogam.infrastructure.jwt;
 
+import jakarta.security.auth.message.AuthException;
 import java.time.LocalDateTime;
+import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import region.jidogam.domain.user.entity.User;
+import region.jidogam.domain.user.exception.UserNotFoundException;
+import region.jidogam.domain.user.repository.UserRepository;
 
 @Slf4j
 @Service
@@ -15,6 +19,7 @@ public class RefreshTokenService {
 
   private final JwtProvider jwtProvider;
   private final RefreshTokenRepository refreshTokenRepository;
+  private final UserRepository userRepository;
 
   @Transactional
   public RefreshToken create(User user) {
@@ -47,5 +52,35 @@ public class RefreshTokenService {
       log.debug("기존 RefreshToken 삭제: userId={}", userId);
       refreshTokenRepository.delete(token);
     });
+  }
+
+  @Transactional(readOnly = true)
+  public String refreshAccessToken(String refreshTokenString) throws AuthException {
+    log.info("RefreshToken으로 AccessToken 재발급 시도");
+
+    // 토큰 유효성 검사
+    if (!jwtProvider.validateToken(refreshTokenString)) {
+      throw new AuthException("Refresh Token이 유효하지 않습니다.");
+    }
+
+    // 토큰 찾기
+    RefreshToken refreshToken = refreshTokenRepository.findByRefreshToken(refreshTokenString)
+        .orElseThrow(() -> new AuthException("Refresh Token이 만료되었거나 존재하지 않습니다."));
+
+    // 토큰 만료 시
+    if (refreshToken.getExpiresAt().isBefore(LocalDateTime.now())) {
+      throw new AuthException("Refresh Token이 만료되었거나 존재하지 않습니다.");
+    }
+
+    // 토큰에서 User ID 추출하여 유저 찾기
+    UUID userId = jwtProvider.extractUserId(refreshTokenString);
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> UserNotFoundException.withId(userId));
+
+    // 유저 정보로 accessToken 재발급
+    String accessToken = jwtProvider.generateAccessToken(user);
+
+    log.info("AccessToken 재발급 완료: userId = {}", userId);
+    return accessToken;
   }
 }

--- a/src/test/java/region/jidogam/infrastructure/jwt/RefreshTokenServiceTest.java
+++ b/src/test/java/region/jidogam/infrastructure/jwt/RefreshTokenServiceTest.java
@@ -1,0 +1,238 @@
+package region.jidogam.infrastructure.jwt;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.security.auth.message.AuthException;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import region.jidogam.domain.user.entity.User;
+import region.jidogam.domain.user.exception.UserNotFoundException;
+import region.jidogam.domain.user.repository.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+class RefreshTokenServiceTest {
+
+  @Mock
+  private JwtProvider jwtProvider;
+  @Mock
+  private RefreshTokenRepository refreshTokenRepository;
+  @Mock
+  private UserRepository userRepository;
+  @InjectMocks
+  private RefreshTokenService refreshTokenService;
+
+  @Nested
+  @DisplayName("refreshToken 생성 테스트")
+  class CreateRefreshTokenTest {
+
+    @Test
+    @DisplayName("성공")
+    void success() {
+      //given
+      UUID userId = UUID.randomUUID();
+      User user = mock(User.class);
+      String refreshTokenString = "refreshToken";
+      LocalDateTime expiresAt = LocalDateTime.now().plusDays(30);
+
+      when(refreshTokenRepository.findByUserId(userId)).thenReturn(Optional.empty());
+      when(jwtProvider.generateRefreshToken(user)).thenReturn(refreshTokenString);
+      when(jwtProvider.extractExpirationTime(refreshTokenString)).thenReturn(expiresAt);
+      when(user.getId()).thenReturn(userId);
+
+      //when 
+      RefreshToken refreshToken = refreshTokenService.create(user);
+
+      //then
+      assertNotNull(refreshToken);
+      assertEquals(userId, refreshToken.getUserId());
+      assertEquals(refreshTokenString, refreshToken.getRefreshToken());
+      assertEquals(expiresAt, refreshToken.getExpiresAt());
+
+      verify(refreshTokenRepository, times(1)).save(any(RefreshToken.class));
+    }
+
+    @Test
+    @DisplayName("이미 발급한 토큰이 있는 경우 삭제 후 성공")
+    void successWhenAlreadyExsitsRefreshToken() {
+      //given
+      UUID userId = UUID.randomUUID();
+      User user = mock(User.class);
+      RefreshToken mockRefreshToken = mock(RefreshToken.class);
+      String refreshTokenString = "refreshToken";
+      LocalDateTime expiresAt = LocalDateTime.now().plusDays(30);
+
+      when(refreshTokenRepository.findByUserId(userId)).thenReturn(Optional.of(mockRefreshToken));
+      when(jwtProvider.generateRefreshToken(user)).thenReturn(refreshTokenString);
+      when(jwtProvider.extractExpirationTime(refreshTokenString)).thenReturn(expiresAt);
+      when(user.getId()).thenReturn(userId);
+
+      //when
+      RefreshToken refreshToken = refreshTokenService.create(user);
+
+      //then
+      assertNotNull(refreshToken);
+      assertEquals(userId, refreshToken.getUserId());
+      assertEquals(refreshTokenString, refreshToken.getRefreshToken());
+      assertEquals(expiresAt, refreshToken.getExpiresAt());
+
+      verify(refreshTokenRepository, times(1)).delete(mockRefreshToken);
+      verify(refreshTokenRepository, times(1)).save(any(RefreshToken.class));
+    }
+  }
+
+  @Nested
+  @DisplayName("refreshToken 삭제 테스트")
+  class DeleteRefreshTokenTest {
+
+    @Test
+    @DisplayName("성공")
+    void success() {
+      //given
+      UUID userId = UUID.randomUUID();
+      User user = mock(User.class);
+      RefreshToken mockRefreshToken = mock(RefreshToken.class);
+
+      when(user.getId()).thenReturn(userId);
+      when(refreshTokenRepository.findByUserId(userId)).thenReturn(Optional.of(mockRefreshToken));
+
+      //when
+      refreshTokenService.delete(user);
+
+      //then
+      verify(refreshTokenRepository, times(1)).delete(mockRefreshToken);
+
+    }
+
+    @Test
+    @DisplayName("토큰이 없는 경우에도 성공 처리")
+    void successWhenNotExistsRefreshToken() {
+      //given
+      UUID userId = UUID.randomUUID();
+      User user = mock(User.class);
+      RefreshToken mockRefreshToken = mock(RefreshToken.class);
+
+      when(user.getId()).thenReturn(userId);
+      when(refreshTokenRepository.findByUserId(userId)).thenReturn(Optional.empty());
+
+      //when
+      refreshTokenService.delete(user);
+
+      //then
+      verify(refreshTokenRepository, never()).delete(mockRefreshToken);
+    }
+
+  }
+
+  @Nested
+  @DisplayName("AccessToken 재발급 테스트")
+  class RefreshAccessTokenTest {
+
+    @Test
+    @DisplayName("성공")
+    void success() throws AuthException {
+      //given
+      UUID userId = UUID.randomUUID();
+      User user = mock(User.class);
+      RefreshToken mockRefreshToken = mock(RefreshToken.class);
+      String refreshTokenString = "refreshToken";
+      LocalDateTime expiresAt = LocalDateTime.now().plusDays(30);
+
+      when(jwtProvider.validateToken(refreshTokenString)).thenReturn(true);
+      when(refreshTokenRepository.findByRefreshToken(refreshTokenString))
+          .thenReturn(Optional.of(mockRefreshToken));
+      when(mockRefreshToken.getExpiresAt()).thenReturn(expiresAt);
+
+      when(jwtProvider.extractUserId(refreshTokenString)).thenReturn(userId);
+      when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+      when(jwtProvider.generateAccessToken(user)).thenReturn("accessToken");
+
+      //when
+      String accessToken = refreshTokenService.refreshAccessToken(refreshTokenString);
+
+      //then
+      assertNotNull(accessToken);
+      assertEquals("accessToken", accessToken);
+    }
+
+    @Test
+    @DisplayName("RefreshToken이 유효햐지 않은 경우")
+    void failsWhenInvalidRefreshToken() {
+      //given
+      String refreshTokenString = "InvalidRefreshToken";
+
+      when(jwtProvider.validateToken(refreshTokenString)).thenReturn(false);
+
+      //when & then
+      assertThrows(AuthException.class,
+          () -> refreshTokenService.refreshAccessToken(refreshTokenString));
+
+    }
+
+
+    @Test
+    @DisplayName("RefreshToken이 존재하지 않는 경우")
+    void failsWhenNotExistsRefreshToken() {
+      //given
+      String refreshTokenString = "refreshTokenNotExists";
+
+      when(jwtProvider.validateToken(refreshTokenString)).thenReturn(true);
+      when(refreshTokenRepository.findByRefreshToken(refreshTokenString)).thenReturn(Optional.empty());
+
+      //when & then
+      assertThrows(AuthException.class,
+          () -> refreshTokenService.refreshAccessToken(refreshTokenString));
+    }
+
+    @Test
+    @DisplayName("RefreshToken이 만료된 경우")
+    void failsWhenExpiredRefreshToken() {
+      //given
+      RefreshToken mockRefreshToken = mock(RefreshToken.class);
+      String refreshTokenString = "expiredRefreshToken";
+      LocalDateTime expiresAt = LocalDateTime.now().minusMinutes(5);
+
+      when(jwtProvider.validateToken(refreshTokenString)).thenReturn(true);
+      when(refreshTokenRepository.findByRefreshToken(refreshTokenString)).thenReturn(Optional.of(mockRefreshToken));
+      when(mockRefreshToken.getExpiresAt()).thenReturn(expiresAt);
+
+      //when & then
+      assertThrows(AuthException.class,
+          () -> refreshTokenService.refreshAccessToken(refreshTokenString));
+    }
+
+    @Test
+    @DisplayName("RefreshToken의 userId가 존재하지 않는 userId인 경우")
+    void failsWhenUserNotExists() {
+      //given
+      UUID userId = UUID.randomUUID();
+      RefreshToken mockRefreshToken = mock(RefreshToken.class);
+      String refreshTokenString = "refreshToken";
+      LocalDateTime expiresAt = LocalDateTime.now().plusDays(30);
+
+      when(jwtProvider.validateToken(refreshTokenString)).thenReturn(true);
+      when(refreshTokenRepository.findByRefreshToken(refreshTokenString)).thenReturn(Optional.of(mockRefreshToken));
+      when(mockRefreshToken.getExpiresAt()).thenReturn(expiresAt);
+
+      when(jwtProvider.extractUserId(refreshTokenString)).thenReturn(userId);
+      when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+      //when & then
+      assertThrows(UserNotFoundException.class,
+          () -> refreshTokenService.refreshAccessToken(refreshTokenString));
+    }
+  }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

#57

## 📝 PR 유형

<!-- 해당하는 유형에 'x'로 체크해주세요. -->

- [x] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug Fix)
- [ ] 코드 개선 (Refactoring)
- [ ] 문서 작업 (Documentation)
- [ ] 환경 설정 (Configuration)
- [ ] 기타 (Other)

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요 (이미지 첨부 가능)

- Implemented functionality to renew access tokens using refresh tokens.
- Added unit tests for scenarios including refresh token creation, deletion, and access token renewal.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## #️⃣닫을 이슈

<!-- 닫을 이슈 번호를 입력해주세요. -->

close #57