### PR TITLE
fix: 회원가입 시 이메일 인증 여부 확인 로직 추가

### DIFF
--- a/src/main/java/region/jidogam/domain/user/exception/UnverifiedEmailException.java
+++ b/src/main/java/region/jidogam/domain/user/exception/UnverifiedEmailException.java
@@ -1,0 +1,11 @@
+package region.jidogam.domain.user.exception;
+
+public class UnverifiedEmailException extends UserException {
+  public UnverifiedEmailException(String message) {
+    super(UserErrorCode.EMAIL_NOT_VARIFIED, message);
+  }
+
+  public static UnverifiedEmailException withEmail(String email) {
+    return new UnverifiedEmailException("'" + email +"' 은 인증되지 않은 이메일입니다.");
+  }
+}

--- a/src/main/java/region/jidogam/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/region/jidogam/domain/user/exception/UserErrorCode.java
@@ -11,7 +11,8 @@ public enum UserErrorCode implements ErrorCode {
   EMAIL_CONFLICT(HttpStatus.CONFLICT, "USER_OO2", "이미 존재하는 이메일입니다."),
   NICKNAME_CONFLICT(HttpStatus.CONFLICT, "USER_OO3", "이미 존재하는 닉네임입니다."),
   NICKNAME_LENGTH_INVALID(HttpStatus.BAD_REQUEST, "USER_O4", "닉네임은 2자 이상, 20자 이하여야 합니다."),
-  EMAIL_FORMAT_INVALID(HttpStatus.BAD_REQUEST, "USER_05", "유효하지 않은 이메일 형식입니다.");
+  EMAIL_FORMAT_INVALID(HttpStatus.BAD_REQUEST, "USER_05", "유효하지 않은 이메일 형식입니다."),
+  EMAIL_NOT_VARIFIED(HttpStatus.FORBIDDEN, "USER_06", "인증된 이메일로만 회원가입할 수 있습니다.");
 
   private HttpStatus status;
   private String code;

--- a/src/main/java/region/jidogam/domain/user/service/UserService.java
+++ b/src/main/java/region/jidogam/domain/user/service/UserService.java
@@ -53,7 +53,7 @@ public class UserService {
     }
 
     EmailAuthCode emailAuthCode = emailAuthCodeRepository.findByEmail(request.email())
-        .orElseThrow(() -> new EmailAuthNotFoundException(request.email())); // 인증 내역 자체가 없음
+        .orElseThrow(() -> EmailAuthNotFoundException.withEmail(request.email())); // 인증 내역 자체가 없음
 
     if (!emailAuthCode.getUsed()) {
       throw UnverifiedEmailException.withEmail(request.email()); // 인증되지 않음

--- a/src/main/java/region/jidogam/domain/user/service/UserService.java
+++ b/src/main/java/region/jidogam/domain/user/service/UserService.java
@@ -7,10 +7,14 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import region.jidogam.domain.auth.entity.EmailAuthCode;
+import region.jidogam.domain.auth.exception.EmailAuthNotFoundException;
+import region.jidogam.domain.auth.repository.EmailAuthCodeRepository;
 import region.jidogam.domain.stamp.entity.Stamp;
 import region.jidogam.domain.stamp.repository.StampRepository;
 import region.jidogam.domain.user.UserMapper;
 import region.jidogam.domain.user.dto.UserDto;
+import region.jidogam.domain.user.exception.UnverifiedEmailException;
 import region.jidogam.domain.user.exception.UserNotFoundException;
 import region.jidogam.infrastructure.jwt.JwtProvider;
 import region.jidogam.infrastructure.jwt.RefreshTokenService;
@@ -35,6 +39,7 @@ public class UserService {
   private final JwtProvider jwtProvider;
   private final RefreshTokenService refreshTokenService;
   private final StampRepository stampRepository;
+  private final EmailAuthCodeRepository emailAuthCodeRepository;
   private final UserMapper userMapper;
 
   @Transactional
@@ -45,6 +50,13 @@ public class UserService {
     }
     if(userRepository.existsByEmail(request.email())){
       throw UserEmailConflictException.withEmail(request.email());
+    }
+
+    EmailAuthCode emailAuthCode = emailAuthCodeRepository.findByEmail(request.email())
+        .orElseThrow(() -> new EmailAuthNotFoundException(request.email())); // 인증 내역 자체가 없음
+
+    if (!emailAuthCode.getUsed()) {
+      throw UnverifiedEmailException.withEmail(request.email()); // 인증되지 않음
     }
 
     User user = User.builder()

--- a/src/test/java/region/jidogam/domain/user/integration/UserCreateIntegrationTest.java
+++ b/src/test/java/region/jidogam/domain/user/integration/UserCreateIntegrationTest.java
@@ -3,6 +3,7 @@ package region.jidogam.domain.user.integration;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -10,6 +11,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
+import region.jidogam.domain.auth.entity.EmailAuthCode;
+import region.jidogam.domain.auth.repository.EmailAuthCodeRepository;
 import region.jidogam.domain.user.dto.UserCreateRequest;
 import region.jidogam.domain.user.entity.User;
 import region.jidogam.domain.user.exception.UserEmailConflictException;
@@ -26,6 +29,9 @@ public class UserCreateIntegrationTest {
   private UserRepository userRepository;
 
   @Autowired
+  private EmailAuthCodeRepository emailAuthCodeRepository;
+
+  @Autowired
   private UserService userService;
 
   @BeforeEach
@@ -37,6 +43,15 @@ public class UserCreateIntegrationTest {
         .build();
 
     userRepository.save(user);
+
+    EmailAuthCode emailAuthCode = EmailAuthCode.builder()
+        .expiresAt(LocalDateTime.now().plusDays(10))
+        .code("TESTAUTHCODE")
+        .email("test@email.com")
+        .used(true)
+        .build();
+
+    emailAuthCodeRepository.save(emailAuthCode);
   }
 
   @Test
@@ -69,7 +84,7 @@ public class UserCreateIntegrationTest {
     UserCreateRequest userCreateRequest = new UserCreateRequest(nickname, email, password);
 
     //when & when
-    assertThrows(UserEmailConflictException.class, ()-> userService.create(userCreateRequest));
+    assertThrows(UserEmailConflictException.class, () -> userService.create(userCreateRequest));
 
     Optional<User> savedUser = userRepository.findByNickname(nickname);
     assertThat(savedUser).isNotPresent();
@@ -86,7 +101,7 @@ public class UserCreateIntegrationTest {
     UserCreateRequest userCreateRequest = new UserCreateRequest(nickname, email, password);
 
     //when & then
-    assertThrows(UserNicknameConflictException.class, ()-> userService.create(userCreateRequest));
+    assertThrows(UserNicknameConflictException.class, () -> userService.create(userCreateRequest));
 
     // then
     Optional<User> savedUser = userRepository.findByEmail(email);

--- a/src/test/java/region/jidogam/domain/user/service/UserServiceTest.java
+++ b/src/test/java/region/jidogam/domain/user/service/UserServiceTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.when;
 import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.UUID;
+import org.h2.command.dml.MergeUsing.When;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -20,11 +21,15 @@ import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import region.jidogam.domain.auth.entity.EmailAuthCode;
+import region.jidogam.domain.auth.exception.EmailAuthNotFoundException;
+import region.jidogam.domain.auth.repository.EmailAuthCodeRepository;
 import region.jidogam.domain.stamp.entity.Stamp;
 import region.jidogam.domain.stamp.repository.StampRepository;
 import region.jidogam.domain.stamp.service.StampService;
 import region.jidogam.domain.user.UserMapper;
 import region.jidogam.domain.user.dto.UserDto;
+import region.jidogam.domain.user.exception.UnverifiedEmailException;
 import region.jidogam.domain.user.exception.UserNotFoundException;
 import region.jidogam.infrastructure.jwt.JwtProvider;
 import region.jidogam.infrastructure.jwt.RefreshToken;
@@ -57,6 +62,9 @@ class UserServiceTest {
   @Mock
   private StampRepository stampRepository;
 
+  @Mock
+  private EmailAuthCodeRepository emailAuthCodeRepository;
+
   @Spy
   private UserMapper userMapper;
 
@@ -74,11 +82,15 @@ class UserServiceTest {
       String nickname = "테스트유저";
       String email = "test@email.com";
       String password = "password1234";
+      EmailAuthCode emailAuthCode = mock(EmailAuthCode.class);
 
       UserCreateRequest userCreateRequest = new UserCreateRequest(nickname, email, password);
 
       when(userRepository.existsByNickname(nickname)).thenReturn(false);
       when(userRepository.existsByEmail(email)).thenReturn(false);
+
+      when(emailAuthCodeRepository.findByEmail(email)).thenReturn(Optional.of(emailAuthCode));
+      when(emailAuthCode.getUsed()).thenReturn(true);
 
       when(passwordEncoder.encode("password1234")).thenReturn("encordedPassword1234");
 
@@ -141,6 +153,50 @@ class UserServiceTest {
       //when & then
       assertThrows(UserEmailConflictException.class,
           () -> userService.create(userCreateRequest));
+
+      verify(userRepository, never()).save(any(User.class));
+    }
+
+    @Test
+    @DisplayName("인증 코드 발송 이력이 없는 이메일")
+    void failsWhenEmailAuthCodeNotFound() {
+      //given
+      String nickname = "테스트유저";
+      String email = "test@email.com";
+      String password = "password1234";
+
+      UserCreateRequest userCreateRequest = new UserCreateRequest(nickname, email, password);
+
+      when(userRepository.existsByNickname(nickname)).thenReturn(false);
+      when(userRepository.existsByEmail(email)).thenReturn(false);
+
+      when(emailAuthCodeRepository.findByEmail(email)).thenReturn(Optional.empty());
+
+      //when & then
+      assertThrows(EmailAuthNotFoundException.class, () -> userService.create(userCreateRequest));
+
+      verify(userRepository, never()).save(any(User.class));
+    }
+
+    @Test
+    @DisplayName("인증 인증 이력이 없는 이메일")
+    void failsWhenEmailAuthCodeNotVarified() {
+      //given
+      String nickname = "테스트유저";
+      String email = "test@email.com";
+      String password = "password1234";
+      EmailAuthCode emailAuthCode = mock(EmailAuthCode.class);
+
+      UserCreateRequest userCreateRequest = new UserCreateRequest(nickname, email, password);
+
+      when(userRepository.existsByNickname(nickname)).thenReturn(false);
+      when(userRepository.existsByEmail(email)).thenReturn(false);
+
+      when(emailAuthCodeRepository.findByEmail(email)).thenReturn(Optional.of(emailAuthCode));
+      when(emailAuthCode.getUsed()).thenReturn(false);
+
+      //when & then
+      assertThrows(UnverifiedEmailException.class, () -> userService.create(userCreateRequest));
 
       verify(userRepository, never()).save(any(User.class));
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

- #73 

## 📝 PR 유형

<!-- 해당하는 유형에 'x'로 체크해주세요. -->

- [ ] 기능 추가 (Feature)
- [x] 버그 수정 (Bug Fix)
- [ ] 코드 개선 (Refactoring)
- [ ] 문서 작업 (Documentation)
- [ ] 환경 설정 (Configuration)
- [ ] 기타 (Other)

## 📝작업 내용
- 회원 가입 도중 이메일 인증 여부를 확인하는 로직을 추가하였습니다.(만약 이메일이 인증되지 않았다면, 예외 발생)
- Updated exception creation to explicitly include email details.
- `UserServiceTest`에 이메일 인증 여부 확인 로직과, 관련 테스트 케이스를 추가하였습니다.


### 스크린샷 (선택)
> 인증 코드 발송 이력이 없는 이메일로 회원가입 시도

<img width="1016" height="466" alt="image" src="https://github.com/user-attachments/assets/cf44ce7a-e954-4274-8f90-2e2a08df48e9" />

<br><br>


> 인증 이력이 없는 이메일로 회원가입 시도

<img width="1009" height="462" alt="image" src="https://github.com/user-attachments/assets/71bdd7c0-2a98-49d0-880d-8c139377efb5" />

<br><br>


> 인증 완료된 이메일로 회원가입 시도 

<img width="1013" height="548" alt="image" src="https://github.com/user-attachments/assets/083550aa-ab73-42c2-8cee-a168440bb8c1" />





## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## #️⃣닫을 이슈

<!-- 닫을 이슈 번호를 입력해주세요. -->

close #73 