### PR TITLE
refactor: 이메일 전송 실패 로깅 및 재시도 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,8 @@ dependencies {
   implementation 'org.springframework.boot:spring-boot-starter-validation'
   implementation 'org.springframework.boot:spring-boot-starter-web'
   implementation 'org.springframework.boot:spring-boot-starter-mail'
+  implementation 'org.springframework.retry:spring-retry'
+  implementation 'org.springframework.boot:spring-boot-starter-aop'
 
   //Security
   implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/src/main/java/region/jidogam/JidogamApplication.java
+++ b/src/main/java/region/jidogam/JidogamApplication.java
@@ -2,8 +2,10 @@ package region.jidogam;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.retry.annotation.EnableRetry;
 
 @SpringBootApplication
+@EnableRetry
 public class JidogamApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/region/jidogam/domain/auth/entity/EmailSendFailureLog.java
+++ b/src/main/java/region/jidogam/domain/auth/entity/EmailSendFailureLog.java
@@ -1,0 +1,25 @@
+package region.jidogam.domain.auth.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import region.jidogam.common.entity.BaseEntity;
+
+@Entity
+@Table(name = "email_send_failure_logs")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class EmailSendFailureLog extends BaseEntity {
+  private String email;
+  private String maskedAuthCode;
+  private String errorMessage;
+  private int retryCount;
+  private LocalDateTime failedAt;
+}

--- a/src/main/java/region/jidogam/domain/auth/repository/EmailSendFailureLogRepository.java
+++ b/src/main/java/region/jidogam/domain/auth/repository/EmailSendFailureLogRepository.java
@@ -1,0 +1,9 @@
+package region.jidogam.domain.auth.repository;
+
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import region.jidogam.domain.auth.entity.EmailSendFailureLog;
+
+public interface EmailSendFailureLogRepository extends JpaRepository<EmailSendFailureLog, UUID> {
+
+}

--- a/src/main/java/region/jidogam/domain/user/event/EmailAuthCodeEventHandler.java
+++ b/src/main/java/region/jidogam/domain/user/event/EmailAuthCodeEventHandler.java
@@ -18,22 +18,11 @@ public class EmailAuthCodeEventHandler {
   @Async
   @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT) // 커밋 후 실행
   public void handleEmailAuthCodeSend(EmailAuthCodeSendEvent event) {
-    try {
-      log.info("이메일 인증 코드 전송 시작: {}", event.email());
+    log.info("이메일 인증 코드 전송 시작: {}", event.email());
       emailService.sendAuthCodeEmail(
           event.email(),
           event.authCode(),
           event.expiration()
       );
-      log.info("이메일 인증 코드 전송 완료: {}", event.email());
-    } catch (Exception e) {
-      log.error("이메일 전송 실패: {}", event.email(), e);
-      handleEmailSendFailure(event, e);
-    }
-  }
-
-  private void handleEmailSendFailure(EmailAuthCodeSendEvent event, Exception e) {
-    log.warn("이메일 전송 실패 후처리 - email: {}, error: {}", event.email(), e.getMessage());
-    // todo - 재시도나 알림 로직 추후 추가하기
   }
 }

--- a/src/main/java/region/jidogam/domain/user/service/EmailService.java
+++ b/src/main/java/region/jidogam/domain/user/service/EmailService.java
@@ -5,12 +5,19 @@ import jakarta.mail.internet.MimeMessage;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.mail.MailException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
+import region.jidogam.domain.auth.entity.EmailSendFailureLog;
+import region.jidogam.domain.auth.repository.EmailSendFailureLogRepository;
 
 @Slf4j
 @Service
@@ -18,21 +25,61 @@ import org.springframework.stereotype.Service;
 public class EmailService {
 
   private final JavaMailSender mailSender;
+  private final EmailSendFailureLogRepository emailSendFailureLogRepository;
+  private final ThreadLocal<Integer> retryCountHolder = ThreadLocal.withInitial(() -> 0);
+
   private static final String EMAIL_TEMPLATE_NAME = "auth-code-email-template.html";
 
   // 이메일 발송
+  @Retryable(
+      retryFor = {MailException.class, RuntimeException.class},
+      maxAttempts = 3,
+      backoff = @Backoff(delay = 2000, multiplier = 2)
+  )
   public void sendAuthCodeEmail(String email, String authCode, Duration expiration) {
     try {
-      log.info("HTML 이메일 발송 시작 - 수신자: {}", email);
+      int currentRetry = retryCountHolder.get();
+      retryCountHolder.set(currentRetry + 1);
+
+      log.info("이메일 인증 코드 전송 시도 ({}/3) - email: {}", retryCountHolder.get(), email);
 
       MimeMessage message = createMimeMessage(email, authCode, expiration);
       mailSender.send(message);
 
-      log.info("HTML 이메일 발송 완료 - 수신자: {}", email);
+      log.info("이메일 인증 코드 전송 완료: {}", email);
+      retryCountHolder.remove();
+
     } catch (MessagingException | IOException e) {
-      log.error("이메일 발송 실패 - 수신자: {}, 에러: {}", email, e.getMessage());
+      log.error("이메일 발송 실패 ({}/3) - 수신자: {}", retryCountHolder.get(), email, e);
       throw new RuntimeException("이메일 발송에 실패했습니다.", e);
     }
+  }
+
+  @Recover
+  public void recover(RuntimeException e, String email, String authCode, Duration expiration) {
+    log.error("이메일 전송 최종 실패 (재시도 3회 모두 실패): {}", email, e);
+    saveFailureLog(email, authCode, e, retryCountHolder.get());
+    retryCountHolder.remove();
+  }
+
+  private void saveFailureLog(String email, String authCode, Exception e, int retryCount) {
+    EmailSendFailureLog failureLog = EmailSendFailureLog.builder()
+        .email(email)
+        .maskedAuthCode(maskAuthCode(authCode))
+        .errorMessage(e.getMessage())
+        .retryCount(retryCount - 1)
+        .failedAt(LocalDateTime.now())
+        .build();
+
+    emailSendFailureLogRepository.save(failureLog);
+    log.info("이메일 전송 실패 로그 저장 완료: email = {}", email);
+  }
+
+  private String maskAuthCode(String authCode) {
+    if (authCode == null || authCode.length() < 4) {
+      return "****";
+    }
+    return authCode.substring(0, 2) + "****";
   }
 
   // MIME 메시지 생성

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -126,6 +126,18 @@ CREATE TABLE email_auth_codes
     used       BOOLEAN                  NOT NULL DEFAULT FALSE
 );
 
+-- Email send failure logs table
+CREATE TABLE email_send_failure_logs
+(
+    id               UUID PRIMARY KEY,
+    email            VARCHAR(255) NOT NULL,
+    masked_auth_code VARCHAR(50),
+    error_message    VARCHAR(1000),
+    retry_count      INT          NOT NULL DEFAULT 0,
+    failed_at        TIMESTAMP WITH TIME ZONE NOT NULL,
+    created_at       TIMESTAMP WITH TIME ZONE NOT NULL
+);
+
 -- Foreign Key Constraints
 ALTER TABLE places
     ADD CONSTRAINT fk_places_area_id

--- a/src/test/java/region/jidogam/domain/user/service/EmailServiceTest.java
+++ b/src/test/java/region/jidogam/domain/user/service/EmailServiceTest.java
@@ -1,0 +1,214 @@
+package region.jidogam.domain.user.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mail.MailSendException;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import region.jidogam.domain.auth.entity.EmailSendFailureLog;
+import region.jidogam.domain.auth.repository.EmailSendFailureLogRepository;
+
+@SpringBootTest
+class EmailServiceTest {
+
+  @Autowired
+  private EmailService emailService;
+
+  @Autowired
+  private EmailSendFailureLogRepository failureLogRepository;
+
+  @MockitoBean
+  private JavaMailSender mailSender;
+
+  private MimeMessage mockMimeMessage;
+
+  @BeforeEach
+  void setUp() {
+    failureLogRepository.deleteAll();
+    mockMimeMessage = mock(MimeMessage.class);
+    when(mailSender.createMimeMessage()).thenReturn(mockMimeMessage);
+  }
+
+  @AfterEach
+  void tearDown() {
+    failureLogRepository.deleteAll();
+  }
+
+  @Test
+  @DisplayName("이메일 전송 성공")
+  void sendAuthCodeEmail_Success() throws Exception {
+    // given
+    String email = "test@example.com";
+    String authCode = "123456";
+    Duration expiration = Duration.ofMinutes(5);
+
+    doNothing().when(mailSender).send(any(MimeMessage.class));
+
+    // when
+    emailService.sendAuthCodeEmail(email, authCode, expiration);
+
+    // then
+    verify(mailSender, times(1)).send(any(MimeMessage.class));
+
+    // 실패 로그가 없어야 함
+    List<EmailSendFailureLog> logs = failureLogRepository.findAll();
+    assertThat(logs).isEmpty();
+  }
+
+  @Test
+  @DisplayName("첫 시도 실패 후 재시도에서 성공")
+  void sendAuthCodeEmail_RetrySuccess() throws Exception {
+    // given
+    String email = "retry@example.com";
+    String authCode = "654321";
+    Duration expiration = Duration.ofMinutes(5);
+
+    // 첫 번째만 실패, 두 번째 성공
+    doThrow(new MailSendException("일시적 오류"))
+        .doNothing()
+        .when(mailSender).send(any(MimeMessage.class));
+
+    // when
+    emailService.sendAuthCodeEmail(email, authCode, expiration);
+
+    // then
+    // 2번 호출됨 (1차 실패 + 2차 성공)
+    verify(mailSender, times(2)).send(any(MimeMessage.class));
+
+    // 실패 로그가 없어야 함 (최종적으로 성공)
+    List<EmailSendFailureLog> logs = failureLogRepository.findAll();
+    assertThat(logs).isEmpty();
+  }
+
+  @Test
+  @DisplayName("이메일 전송 3회 모두 실패 시 DB에 실패 로그 저장")
+  void sendAuthCodeEmail_AllRetriesFailed() throws Exception {
+    // given
+    String email = "fail@example.com";
+    String authCode = "999999";
+    Duration expiration = Duration.ofMinutes(5);
+
+    doThrow(new MailSendException("SMTP 서버 연결 실패"))
+        .when(mailSender).send(any(MimeMessage.class));
+
+    // when & then
+    assertDoesNotThrow(() ->
+        emailService.sendAuthCodeEmail(email, authCode, expiration)
+    );
+
+    // 3번 시도됨
+    verify(mailSender, times(3)).send(any(MimeMessage.class));
+
+    // 실패 로그 확인
+    List<EmailSendFailureLog> logs = failureLogRepository.findAll();
+    assertThat(logs).hasSize(1);
+    assertThat(logs.get(0).getEmail()).isEqualTo(email);
+    assertThat(logs.get(0).getMaskedAuthCode()).isEqualTo("99****");
+    assertThat(logs.get(0).getRetryCount()).isEqualTo(2); // 2번 재시도
+    assertThat(logs.get(0).getErrorMessage()).contains("SMTP 서버 연결 실패");
+    assertThat(logs.get(0).getFailedAt()).isNotNull();
+  }
+
+  @Test
+  @DisplayName("두 번째 시도에서 성공")
+  void sendAuthCodeEmail_SecondAttemptSuccess() throws Exception {
+    // given
+    String email = "second@example.com";
+    String authCode = "111111";
+    Duration expiration = Duration.ofMinutes(5);
+
+    doThrow(new MailSendException("네트워크 오류"))
+        .doNothing()
+        .when(mailSender).send(any(MimeMessage.class));
+
+    // when
+    emailService.sendAuthCodeEmail(email, authCode, expiration);
+
+    // then
+    verify(mailSender, times(2)).send(any(MimeMessage.class));
+
+    List<EmailSendFailureLog> logs = failureLogRepository.findAll();
+    assertThat(logs).isEmpty();
+  }
+
+  @Test
+  @DisplayName("MessagingException 발생 시 재시도 후 실패 로그 저장")
+  void sendAuthCodeEmail_MessagingException() throws Exception {
+    // given
+    String email = "messaging@example.com";
+    String authCode = "222222";
+    Duration expiration = Duration.ofMinutes(5);
+
+    doThrow(new RuntimeException("이메일 발송에 실패했습니다.", new MessagingException("메시지 생성 실패")))
+        .when(mailSender).send(any(MimeMessage.class));
+
+    // when & then
+    assertDoesNotThrow(() ->
+        emailService.sendAuthCodeEmail(email, authCode, expiration)
+    );
+
+    verify(mailSender, times(3)).send(any(MimeMessage.class));
+
+    List<EmailSendFailureLog> logs = failureLogRepository.findAll();
+    assertThat(logs).hasSize(1);
+    assertThat(logs.get(0).getEmail()).isEqualTo(email);
+    assertThat(logs.get(0).getMaskedAuthCode()).isEqualTo("22****");
+    assertThat(logs.get(0).getFailedAt()).isNotNull();
+  }
+
+  @Test
+  @DisplayName("인증 코드 마스킹 확인")
+  void authCodeMasking() throws Exception {
+    // given
+    String email = "mask@example.com";
+    String authCode = "ABCDEF";
+    Duration expiration = Duration.ofMinutes(5);
+
+    doThrow(new MailSendException("실패"))
+        .when(mailSender).send(any(MimeMessage.class));
+
+    // when & then
+    assertDoesNotThrow(() ->
+        emailService.sendAuthCodeEmail(email, authCode, expiration)
+    );
+
+    List<EmailSendFailureLog> logs = failureLogRepository.findAll();
+    assertThat(logs).hasSize(1);
+    assertThat(logs.get(0).getMaskedAuthCode()).isEqualTo("AB****");
+  }
+
+  @Test
+  @DisplayName("짧은 인증 코드도 마스킹 처리")
+  void shortAuthCodeMasking() throws Exception {
+    // given
+    String email = "short@example.com";
+    String authCode = "12";
+    Duration expiration = Duration.ofMinutes(5);
+
+    doThrow(new MailSendException("실패"))
+        .when(mailSender).send(any(MimeMessage.class));
+
+    // when & then
+    assertDoesNotThrow(() ->
+        emailService.sendAuthCodeEmail(email, authCode, expiration)
+    );
+
+    List<EmailSendFailureLog> logs = failureLogRepository.findAll();
+    assertThat(logs).hasSize(1);
+    assertThat(logs.get(0).getMaskedAuthCode()).isEqualTo("****");
+  }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

- #79 

## 📝 PR 유형

<!-- 해당하는 유형에 'x'로 체크해주세요. -->

- [ ] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug Fix)
- [x] 코드 개선 (Refactoring)
- [ ] 문서 작업 (Documentation)
- [ ] 환경 설정 (Configuration)
- [ ] 기타 (Other)

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요 (이미지 첨부 가능)

- Spring Retry를 활용한 이메일 발송 재시도 로직 구현
- 재시도 실패 시 데이터베이스에 실패 이력 로깅
- 관련 엔티티, 리포지토리 및 테스트 코드 추가


### 스크린샷 

> 전송 성공

<img width="1515" height="507" alt="image" src="https://github.com/user-attachments/assets/bd4971a5-55c3-41f7-b3c6-982c16441d55" />

<br> 


> 3회 모두 실패 시

<img width="1150" height="521" alt="image" src="https://github.com/user-attachments/assets/9e630dec-a48a-4932-a17d-960964dc59f5" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## #️⃣닫을 이슈

<!-- 닫을 이슈 번호를 입력해주세요. -->

close #79 