### PR TITLE
chore: @CurrentUserId 어노테이션에 Swagger hidden 속성 적용

### DIFF
--- a/src/main/java/region/jidogam/common/annotation/CurrentUserId.java
+++ b/src/main/java/region/jidogam/common/annotation/CurrentUserId.java
@@ -1,5 +1,6 @@
 package region.jidogam.common.annotation;
 
+import io.swagger.v3.oas.annotations.Parameter;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -7,6 +8,7 @@ import java.lang.annotation.Target;
 
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
+@Parameter(hidden = true)
 public @interface CurrentUserId {
 
 }

--- a/src/main/java/region/jidogam/common/config/SwaggerConfig.java
+++ b/src/main/java/region/jidogam/common/config/SwaggerConfig.java
@@ -5,10 +5,8 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
-import org.springdoc.core.customizers.OperationCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import region.jidogam.common.annotation.CurrentUserId;
 
 @Configuration
 public class SwaggerConfig {
@@ -36,20 +34,5 @@ public class SwaggerConfig {
         .title("지도감 Swagger")
         .description("지도감 REST API")
         .version("1.0.0");
-  }
-
-  @Bean
-  public OperationCustomizer operationCustomizer() {
-    return (operation, handlerMethod) -> {
-      for (var parameter : handlerMethod.getMethodParameters()) {
-        if (parameter.hasParameterAnnotation(CurrentUserId.class)) {
-          String paramName = parameter.getParameterName();
-          if (operation.getParameters() != null) {
-            operation.getParameters().removeIf(p -> p.getName().equals(paramName));
-          }
-        }
-      }
-      return operation;
-    };
   }
 }

--- a/src/main/java/region/jidogam/domain/user/controller/UserApi.java
+++ b/src/main/java/region/jidogam/domain/user/controller/UserApi.java
@@ -92,7 +92,7 @@ public interface UserApi {
       @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
   })
   ResponseEntity<UserDto> getProfile(
-      @Parameter(hidden = true) @CurrentUserId UUID userId
+      @CurrentUserId UUID userId
   );
 
   @Operation(summary = "사용자 가이드북 목록 조회", description = "특정 사용자가 작성한 가이드북 목록을 조회합니다.")
@@ -102,7 +102,7 @@ public interface UserApi {
       @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
   })
   ResponseEntity<CursorPageResponseDto<GuidebookResponse>> getGuidebooks(
-      @Parameter(hidden = true) @CurrentUserId UUID userId,
+      @CurrentUserId UUID userId,
       @Parameter(description = "가이드북 작성자 ID", required = true) @PathVariable UUID authorId,
       @Valid @ModelAttribute UserGuidebookSearchRequest request
   );
@@ -116,7 +116,7 @@ public interface UserApi {
       @ApiResponse(responseCode = "409", description = "닉네임 중복")
   })
   ResponseEntity<UserDto> updateProfile(
-      @Parameter(hidden = true) @CurrentUserId UUID userId,
+      @CurrentUserId UUID userId,
       @Valid @RequestBody UserUpdateRequest request
   );
 
@@ -126,7 +126,7 @@ public interface UserApi {
       @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
   })
   ResponseEntity<CursorPageResponseDto<PlaceResponse>> getStamps(
-      @Parameter(hidden = true) @CurrentUserId UUID currentUserId,
+      @CurrentUserId UUID currentUserId,
       @Valid @ModelAttribute StampSearchRequest request
   );
 
@@ -137,7 +137,7 @@ public interface UserApi {
       @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
   })
   ResponseEntity<CursorPageResponseDto<GuidebookParticipationResponse>> getParticipation(
-      @Parameter(hidden = true) @CurrentUserId UUID currentUserId,
+      @CurrentUserId UUID currentUserId,
       @Parameter(description = "조회할 사용자 ID", required = true) @PathVariable UUID userId,
       @Valid @ModelAttribute GuidebookParticipationSearchRequest request
   );
@@ -148,7 +148,7 @@ public interface UserApi {
       @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
   })
   ResponseEntity<Void> delete(
-      @Parameter(hidden = true) @CurrentUserId UUID userId
+      @CurrentUserId UUID userId
   );
 
   @Operation(summary = "계정 복구", description = "탈퇴한 계정을 복구합니다.")


### PR DESCRIPTION
## #️⃣연관된 이슈

- #124

## 📝 PR 유형

- [x] 코드 개선 (Refactoring)

## 📝작업 내용

### 문제
기존 `OperationCustomizer`를 통한 `@CurrentUserId` 파라미터 제거 로직이 정상 동작하지 않음
- `parameter.getParameterName()`이 null을 반환하거나 Swagger 파라미터 이름과 불일치

### 해결
`@CurrentUserId` 어노테이션 자체에 `@Parameter(hidden = true)`를 메타 어노테이션으로 추가하여 해결

### 변경 사항
1. **CurrentUserId.java**: `@Parameter(hidden = true)` 메타 어노테이션 추가
2. **SwaggerConfig.java**: 불필요해진 `OperationCustomizer` 빈 제거
3. **UserApi.java**: 중복된 `@Parameter(hidden = true)` 어노테이션 제거 (6개 메서드)

### 장점
- 모든 `@CurrentUserId` 사용처에 자동 적용
- 코드 중복 제거
- 유지보수 용이

## #️⃣닫을 이슈
close #124