### PR TITLE
feat: 관리자 로그인/홈 페이지 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,10 @@ dependencies {
   //Security
   implementation 'org.springframework.boot:spring-boot-starter-security'
 
+  // Thymeleaf
+  implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+  implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
+
   // DB
   implementation 'com.h2database:h2'
   implementation 'org.postgresql:postgresql'

--- a/src/main/java/region/jidogam/common/config/PublicApiEndpoints.java
+++ b/src/main/java/region/jidogam/common/config/PublicApiEndpoints.java
@@ -35,6 +35,11 @@ public final class PublicApiEndpoints {
   public static final String GUIDEBOOK_PLACE_LIST = "/api/guidebooks/*/places";
   public static final String NEARBY_PLACE_LIST = "/api/places/nearby";
 
+  // 관리자 페이지 (정적 리소스)
+  public static final String ADMIN_PAGES = "/jidogam-admin/**";
+  public static final String STATIC_CSS = "/css/**";
+  public static final String FAVICON = "/favicon.ico";
+
   /**
    * 모든 공개 POST API 엔드포인트를 반환
    */
@@ -63,7 +68,10 @@ public final class PublicApiEndpoints {
         POPULAR_GUIDEBOOK_LIST,
         NEARBY_PLACE_LIST,
         GUIDEBOOK_PLACE_LIST,
-        ACTUATOR
+        ACTUATOR,
+        ADMIN_PAGES,
+        STATIC_CSS,
+        FAVICON
     };
   }
 }

--- a/src/main/java/region/jidogam/domain/admin/controller/AdminPageController.java
+++ b/src/main/java/region/jidogam/domain/admin/controller/AdminPageController.java
@@ -1,0 +1,20 @@
+package region.jidogam.domain.admin.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/jidogam-admin")
+public class AdminPageController {
+
+  @GetMapping("/login")
+  public String loginPage() {
+    return "admin/login";
+  }
+
+  @GetMapping("/home")
+  public String homePage() {
+    return "admin/home";
+  }
+}

--- a/src/main/resources/static/css/admin.css
+++ b/src/main/resources/static/css/admin.css
@@ -1,0 +1,268 @@
+@import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css');
+
+:root {
+  --gray0: #FFFFFF;
+  --gray50: #F5F5F5;
+  --gray100: #FAFBF7;
+  --gray200: #F2F4ED;
+  --gray300: #E6E8DF;
+  --gray400: #D5D8CD;
+  --gray500: #BFC1B6;
+  --gray600: #A1A499;
+  --gray700: #7C7F76;
+  --gray800: #52534E;
+  --gray900: #262624;
+
+  --primary50: #F7FBEA;
+  --primary100: #E9F6C0;
+  --primary200: #A6C154;
+  --primary300: #A2CD20;
+  --primary400: #7EA310;
+
+  --red50: #FFD7D4;
+  --red100: #FB7D74;
+  --red200: #F03E31;
+  --red300: #DC1D10;
+  --red400: #BF1004;
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Pretendard', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: var(--gray50);
+  color: var(--gray900);
+  line-height: 1.6;
+}
+
+/* ── Login Page ── */
+.login-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  background: var(--gray100);
+}
+
+.login-card {
+  background: var(--gray0);
+  border-radius: 16px;
+  padding: 48px 40px;
+  width: 100%;
+  max-width: 420px;
+  box-shadow: 0 4px 24px rgba(38, 38, 36, 0.08);
+}
+
+.login-card h1 {
+  font-size: 24px;
+  font-weight: 700;
+  color: var(--gray900);
+  text-align: center;
+  margin-bottom: 8px;
+}
+
+.login-card .subtitle {
+  font-size: 14px;
+  color: var(--gray600);
+  text-align: center;
+  margin-bottom: 32px;
+}
+
+.form-group {
+  margin-bottom: 16px;
+}
+
+.form-group label {
+  display: block;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--gray700);
+  margin-bottom: 6px;
+}
+
+.form-group input {
+  width: 100%;
+  padding: 12px 16px;
+  border: 1px solid var(--gray300);
+  border-radius: 8px;
+  font-size: 15px;
+  font-family: inherit;
+  color: var(--gray900);
+  background: var(--gray0);
+  transition: border-color 0.2s;
+  outline: none;
+}
+
+.form-group input:focus {
+  border-color: var(--primary300);
+  box-shadow: 0 0 0 3px rgba(162, 205, 32, 0.15);
+}
+
+.form-group input::placeholder {
+  color: var(--gray500);
+}
+
+.btn-login {
+  width: 100%;
+  padding: 14px;
+  background: var(--primary300);
+  color: var(--gray0);
+  border: none;
+  border-radius: 8px;
+  font-size: 16px;
+  font-weight: 600;
+  font-family: inherit;
+  cursor: pointer;
+  transition: background 0.2s;
+  margin-top: 8px;
+}
+
+.btn-login:hover {
+  background: var(--primary400);
+}
+
+.message-error {
+  background: var(--red50);
+  color: var(--red300);
+  padding: 12px 16px;
+  border-radius: 8px;
+  font-size: 14px;
+  margin-bottom: 20px;
+  text-align: center;
+}
+
+.message-info {
+  background: var(--primary50);
+  color: var(--primary400);
+  padding: 12px 16px;
+  border-radius: 8px;
+  font-size: 14px;
+  margin-bottom: 20px;
+  text-align: center;
+}
+
+/* ── Home Page ── */
+.admin-layout {
+  display: flex;
+  min-height: 100vh;
+}
+
+.sidebar {
+  width: 240px;
+  background: var(--gray900);
+  color: var(--gray0);
+  padding: 24px 0;
+  flex-shrink: 0;
+}
+
+.sidebar-logo {
+  font-size: 18px;
+  font-weight: 700;
+  padding: 0 24px 24px;
+  border-bottom: 1px solid var(--gray800);
+  margin-bottom: 16px;
+}
+
+.sidebar-nav {
+  list-style: none;
+}
+
+.sidebar-nav li a {
+  display: block;
+  padding: 12px 24px;
+  color: var(--gray400);
+  text-decoration: none;
+  font-size: 14px;
+  font-weight: 500;
+  transition: all 0.2s;
+}
+
+.sidebar-nav li a:hover,
+.sidebar-nav li a.active {
+  color: var(--gray0);
+  background: var(--gray800);
+}
+
+.main-content {
+  flex: 1;
+  background: var(--gray50);
+}
+
+.top-bar {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  padding: 16px 32px;
+  background: var(--gray0);
+  border-bottom: 1px solid var(--gray300);
+}
+
+.top-bar .admin-info {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.top-bar .admin-name {
+  font-size: 14px;
+  color: var(--gray700);
+  font-weight: 500;
+}
+
+.btn-logout {
+  padding: 8px 16px;
+  background: var(--gray0);
+  color: var(--gray700);
+  border: 1px solid var(--gray300);
+  border-radius: 6px;
+  font-size: 13px;
+  font-family: inherit;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.btn-logout:hover {
+  background: var(--gray50);
+  border-color: var(--gray400);
+}
+
+.content-area {
+  padding: 32px;
+}
+
+.content-area h2 {
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--gray900);
+  margin-bottom: 24px;
+}
+
+.dashboard-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 20px;
+}
+
+.dashboard-card {
+  background: var(--gray0);
+  border-radius: 12px;
+  padding: 24px;
+  box-shadow: 0 2px 8px rgba(38, 38, 36, 0.06);
+}
+
+.dashboard-card .card-label {
+  font-size: 13px;
+  color: var(--gray600);
+  margin-bottom: 8px;
+  font-weight: 500;
+}
+
+.dashboard-card .card-value {
+  font-size: 28px;
+  font-weight: 700;
+  color: var(--gray900);
+}

--- a/src/main/resources/templates/admin/home.html
+++ b/src/main/resources/templates/admin/home.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>지도감 관리자</title>
+  <link rel="stylesheet" th:href="@{/css/admin.css}">
+</head>
+<body>
+  <div class="admin-layout">
+    <aside class="sidebar">
+      <div class="sidebar-logo">지도감 Admin</div>
+      <ul class="sidebar-nav">
+        <li><a href="/jidogam-admin/home" class="active">홈</a></li>
+      </ul>
+    </aside>
+
+    <div class="main-content">
+      <header class="top-bar">
+        <div class="admin-info">
+          <span class="admin-name" id="adminName">관리자</span>
+          <button type="button" class="btn-logout" id="logoutBtn">로그아웃</button>
+        </div>
+      </header>
+
+      <main class="content-area">
+        <h2>대시보드</h2>
+        <div class="dashboard-cards">
+          <div class="dashboard-card">
+            <div class="card-label">환영합니다</div>
+            <div class="card-value" style="font-size: 18px;">지도감 관리자 페이지입니다.</div>
+          </div>
+        </div>
+      </main>
+    </div>
+  </div>
+
+  <script>
+    const token = localStorage.getItem('adminToken');
+
+    if (!token) {
+      location.href = '/jidogam-admin/login';
+    }
+
+    document.getElementById('logoutBtn').addEventListener('click', () => {
+      localStorage.removeItem('adminToken');
+      location.href = '/jidogam-admin/login';
+    });
+  </script>
+</body>
+</html>

--- a/src/main/resources/templates/admin/login.html
+++ b/src/main/resources/templates/admin/login.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>지도감 관리자 로그인</title>
+  <link rel="stylesheet" th:href="@{/css/admin.css}">
+</head>
+<body>
+  <div class="login-container">
+    <div class="login-card">
+      <h1>지도감</h1>
+      <p class="subtitle">관리자 로그인</p>
+
+      <div id="errorMessage" class="message-error" style="display:none;"></div>
+
+      <form id="loginForm">
+        <div class="form-group">
+          <label for="email">이메일</label>
+          <input type="email" id="email" placeholder="admin@jidogam.com" required autofocus>
+        </div>
+
+        <div class="form-group">
+          <label for="password">비밀번호</label>
+          <input type="password" id="password" placeholder="비밀번호를 입력하세요" required>
+        </div>
+
+        <button type="submit" class="btn-login">로그인</button>
+      </form>
+    </div>
+  </div>
+
+  <script>
+    // 이미 로그인 상태면 홈으로 이동
+    if (localStorage.getItem('adminToken')) {
+      location.href = '/jidogam-admin/home';
+    }
+
+    document.getElementById('loginForm').addEventListener('submit', async (e) => {
+      e.preventDefault();
+
+      const errorDiv = document.getElementById('errorMessage');
+      errorDiv.style.display = 'none';
+
+      const email = document.getElementById('email').value;
+      const password = document.getElementById('password').value;
+
+      try {
+        const res = await fetch('/api/auth/login', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email, password })
+        });
+
+        if (!res.ok) {
+          const data = await res.json();
+          errorDiv.textContent = data.message || '이메일 또는 비밀번호가 올바르지 않습니다.';
+          errorDiv.style.display = 'block';
+          return;
+        }
+
+        const data = await res.json();
+        localStorage.setItem('adminToken', data.accessToken);
+        location.href = '/jidogam-admin/home';
+      } catch (err) {
+        errorDiv.textContent = '서버 연결에 실패했습니다.';
+        errorDiv.style.display = 'block';
+      }
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## #️⃣연관된 이슈

- #152

## 📝 PR 유형

- [x] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug Fix)
- [ ] 코드 개선 (Refactoring)
- [ ] 문서 작업 (Documentation)
- [ ] 환경 설정 (Configuration)
- [ ] 기타 (Other)

## 📝작업 내용

> 관리자 로그인 페이지와 홈 페이지를 Thymeleaf + JS 기반으로 구현했습니다.

### 변경사항

**1. 관리자 페이지 초기 구성 **
- `admin.css`: 프로젝트 디자인 시스템 컬러(gray, primary, red) 및 Pretendard 폰트 적용
- `login.html`: 기존 `/api/auth/login` API를 JS fetch로 호출, JWT를 localStorage에 저장
- `home.html`: 사이드바 + 대시보드 레이아웃, 토큰 없으면 로그인으로 리다이렉트

**2. 관리자 페이지 컨트롤러 **
- `AdminPageController`: `/jidogam-admin/login`, `/jidogam-admin/home` 뷰 라우팅

**3. 공개 엔드포인트 추가 **
- `PublicApiEndpoints`에 `/jidogam-admin/**`, `/css/**`, `/favicon.ico` 추가

### 설계 결정

- 별도의 SecurityFilterChain(세션 기반)을 분리하는 대신, 기존 JWT 인증 API를 JS에서 호출하는 방식을 채택했습니다. 
- SecurityConfig 변경 없이 공개 경로 추가만으로 구현하여 기존 구조와의 일관성을 유지했습니다.

### 스크린샷 (선택)

> 로그인 페이지

<img width="1512" height="891" alt="image" src="https://github.com/user-attachments/assets/1564c9af-c977-4be6-a97f-66cdd31692aa" />

<br><br>

> 홈 화면

<img width="1506" height="920" alt="image" src="https://github.com/user-attachments/assets/43192eb7-dda6-461b-8cc9-00a33ffa9df2" />


## 💬리뷰 요구사항(선택)

## #️⃣닫을 이슈

close #152