### PR TITLE
feat: 어드민 사용자 관리 기능 구현 (#163)

### DIFF
--- a/src/main/java/region/jidogam/common/config/SecurityConfig.java
+++ b/src/main/java/region/jidogam/common/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.boot.actuate.autoconfigure.security.servlet.EndpointRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -24,12 +25,35 @@ public class SecurityConfig {
   private final JidogamUserDetailsService jidogamUserDetailsService;
 
   @Bean
-  public SecurityFilterChain securityFilterChain(
+  @Order(1)
+  public SecurityFilterChain adminFilterChain(HttpSecurity http) throws Exception {
+    http
+        .securityMatcher("/admin/**", "/css/**")
+
+        .csrf(AbstractHttpConfigurer::disable)
+
+        .sessionManagement(session -> session
+            .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+
+        .authorizeHttpRequests(auth -> auth
+            .requestMatchers("/admin/login", "/admin/api/**", "/css/**").permitAll()
+            .anyRequest().hasRole("ADMIN"))
+
+        .addFilterBefore(
+            new JwtAuthenticationFilter(jwtProvider, jidogamUserDetailsService),
+            UsernamePasswordAuthenticationFilter.class);
+
+    return http.build();
+  }
+
+  @Bean
+  @Order(2)
+  public SecurityFilterChain apiFilterChain(
       HttpSecurity http,
       AccessDeniedHandler accessDeniedHandler,
       AuthenticationEntryPoint authenticationEntryPoint) throws Exception {
     http
-        .csrf(AbstractHttpConfigurer::disable) // REST API
+        .csrf(AbstractHttpConfigurer::disable)
 
         .sessionManagement(session -> session
             .sessionCreationPolicy(SessionCreationPolicy.STATELESS))

--- a/src/main/java/region/jidogam/common/config/SecurityConfig.java
+++ b/src/main/java/region/jidogam/common/config/SecurityConfig.java
@@ -28,7 +28,7 @@ public class SecurityConfig {
   @Order(1)
   public SecurityFilterChain adminFilterChain(HttpSecurity http) throws Exception {
     http
-        .securityMatcher("/admin/**", "/css/**")
+        .securityMatcher("/jidogam-admin/**", "/css/**")
 
         .csrf(AbstractHttpConfigurer::disable)
 
@@ -36,7 +36,7 @@ public class SecurityConfig {
             .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 
         .authorizeHttpRequests(auth -> auth
-            .requestMatchers("/admin/login", "/admin/api/**", "/css/**").permitAll()
+            .requestMatchers("/jidogam-admin/login", "/jidogam-admin/api/**", "/css/**").permitAll()
             .anyRequest().hasRole("ADMIN"))
 
         .addFilterBefore(

--- a/src/main/java/region/jidogam/domain/admin/controller/AdminAuthController.java
+++ b/src/main/java/region/jidogam/domain/admin/controller/AdminAuthController.java
@@ -12,7 +12,7 @@ import region.jidogam.domain.admin.dto.AdminLoginRequest;
 import region.jidogam.domain.admin.service.AdminAuthService;
 
 @RestController
-@RequestMapping("/admin/api")
+@RequestMapping("/jidogam-admin/api")
 @RequiredArgsConstructor
 public class AdminAuthController {
 

--- a/src/main/java/region/jidogam/domain/admin/controller/AdminAuthController.java
+++ b/src/main/java/region/jidogam/domain/admin/controller/AdminAuthController.java
@@ -1,0 +1,51 @@
+package region.jidogam.domain.admin.controller;
+
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import region.jidogam.domain.admin.dto.AdminLoginRequest;
+import region.jidogam.domain.admin.service.AdminAuthService;
+
+@RestController
+@RequestMapping("/admin/api")
+@RequiredArgsConstructor
+public class AdminAuthController {
+
+  private final AdminAuthService adminAuthService;
+
+  @PostMapping("/login")
+  public ResponseEntity<Void> login(@RequestBody AdminLoginRequest request,
+      HttpServletResponse response) {
+    String accessToken = adminAuthService.login(request);
+
+    ResponseCookie cookie = ResponseCookie.from("access_token", accessToken)
+        .httpOnly(true)
+        .secure(false) // 개발환경, 운영에서는 true
+        .path("/")
+        .sameSite("Lax")
+        .maxAge(3600) // 1시간
+        .build();
+    response.addHeader("Set-Cookie", cookie.toString());
+
+    return ResponseEntity.ok().build();
+  }
+
+  @PostMapping("/logout")
+  public ResponseEntity<Void> logout(HttpServletResponse response) {
+    ResponseCookie cookie = ResponseCookie.from("access_token", "")
+        .httpOnly(true)
+        .secure(false)
+        .path("/")
+        .sameSite("Lax")
+        .maxAge(0)
+        .build();
+    response.addHeader("Set-Cookie", cookie.toString());
+
+    return ResponseEntity.ok().build();
+  }
+}

--- a/src/main/java/region/jidogam/domain/admin/controller/AdminAuthController.java
+++ b/src/main/java/region/jidogam/domain/admin/controller/AdminAuthController.java
@@ -2,6 +2,7 @@ package region.jidogam.domain.admin.controller;
 
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -18,6 +19,9 @@ public class AdminAuthController {
 
   private final AdminAuthService adminAuthService;
 
+  @Value("${jidogam.admin.cookie.secure}")
+  private boolean cookieSecure;
+
   @PostMapping("/login")
   public ResponseEntity<Void> login(@RequestBody AdminLoginRequest request,
       HttpServletResponse response) {
@@ -25,7 +29,7 @@ public class AdminAuthController {
 
     ResponseCookie cookie = ResponseCookie.from("access_token", accessToken)
         .httpOnly(true)
-        .secure(false) // 개발환경, 운영에서는 true
+        .secure(cookieSecure)
         .path("/")
         .sameSite("Lax")
         .maxAge(3600) // 1시간
@@ -39,7 +43,7 @@ public class AdminAuthController {
   public ResponseEntity<Void> logout(HttpServletResponse response) {
     ResponseCookie cookie = ResponseCookie.from("access_token", "")
         .httpOnly(true)
-        .secure(false)
+        .secure(cookieSecure)
         .path("/")
         .sameSite("Lax")
         .maxAge(0)

--- a/src/main/java/region/jidogam/domain/admin/controller/AdminUserController.java
+++ b/src/main/java/region/jidogam/domain/admin/controller/AdminUserController.java
@@ -1,0 +1,87 @@
+package region.jidogam.domain.admin.controller;
+
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import region.jidogam.domain.admin.dto.AdminUserResponse;
+import region.jidogam.domain.admin.dto.AdminUserSearchRequest;
+import region.jidogam.domain.admin.dto.AdminUserUpdateRequest;
+import region.jidogam.domain.admin.service.AdminUserService;
+import region.jidogam.domain.user.entity.User;
+
+@Controller
+@RequestMapping("/admin/users")
+@RequiredArgsConstructor
+public class AdminUserController {
+
+  private final AdminUserService adminUserService;
+
+  @GetMapping
+  public String userList(
+      @RequestParam(value = "keyword", required = false) String keyword,
+      @RequestParam(value = "role", required = false) User.Role role,
+      @RequestParam(value = "deleted", required = false) Boolean deleted,
+      @RequestParam(value = "page", required = false) Integer page,
+      @RequestParam(value = "size", required = false) Integer size,
+      Model model) {
+
+    AdminUserSearchRequest request = AdminUserSearchRequest.of(keyword, role, deleted, page, size);
+    Page<AdminUserResponse> users = adminUserService.getUsers(request);
+
+    model.addAttribute("users", users);
+    model.addAttribute("keyword", keyword);
+    model.addAttribute("role", role);
+    model.addAttribute("deleted", deleted);
+
+    return "admin/users/list";
+  }
+
+  @GetMapping("/{userId}")
+  public String userDetail(@PathVariable UUID userId, Model model) {
+    AdminUserResponse user = adminUserService.getUser(userId);
+    model.addAttribute("user", user);
+    return "admin/users/detail";
+  }
+
+  @GetMapping("/{userId}/edit")
+  public String userEditForm(@PathVariable UUID userId, Model model) {
+    AdminUserResponse user = adminUserService.getUser(userId);
+    model.addAttribute("user", user);
+    return "admin/users/edit";
+  }
+
+  @PostMapping("/{userId}/edit")
+  public String userUpdate(
+      @PathVariable UUID userId,
+      @RequestParam(value = "nickname", required = false) String nickname,
+      @RequestParam(value = "role", required = false) User.Role role,
+      RedirectAttributes redirectAttributes) {
+
+    AdminUserUpdateRequest request = new AdminUserUpdateRequest(nickname, role);
+    adminUserService.updateUser(userId, request);
+    redirectAttributes.addFlashAttribute("successMessage", "사용자 정보가 수정되었습니다.");
+    return "redirect:/admin/users/" + userId;
+  }
+
+  @PostMapping("/{userId}/delete")
+  public String userDelete(@PathVariable UUID userId, RedirectAttributes redirectAttributes) {
+    adminUserService.deleteUser(userId);
+    redirectAttributes.addFlashAttribute("successMessage", "사용자가 삭제되었습니다.");
+    return "redirect:/admin/users/" + userId;
+  }
+
+  @PostMapping("/{userId}/restore")
+  public String userRestore(@PathVariable UUID userId, RedirectAttributes redirectAttributes) {
+    adminUserService.restoreUser(userId);
+    redirectAttributes.addFlashAttribute("successMessage", "사용자가 복구되었습니다.");
+    return "redirect:/admin/users/" + userId;
+  }
+}

--- a/src/main/java/region/jidogam/domain/admin/controller/AdminUserController.java
+++ b/src/main/java/region/jidogam/domain/admin/controller/AdminUserController.java
@@ -19,7 +19,7 @@ import region.jidogam.domain.admin.service.AdminUserService;
 import region.jidogam.domain.user.entity.User;
 
 @Controller
-@RequestMapping("/admin/users")
+@RequestMapping("/jidogam-admin/users")
 @RequiredArgsConstructor
 public class AdminUserController {
 
@@ -70,7 +70,7 @@ public class AdminUserController {
     AdminUserUpdateRequest request = new AdminUserUpdateRequest(nickname, role);
     adminUserService.updateUser(userId, request, currentAdminId);
     redirectAttributes.addFlashAttribute("successMessage", "사용자 정보가 수정되었습니다.");
-    return "redirect:/admin/users/" + userId;
+    return "redirect:/jidogam-admin/users/" + userId;
   }
 
   @PostMapping("/{userId}/delete")
@@ -80,13 +80,13 @@ public class AdminUserController {
       RedirectAttributes redirectAttributes) {
     adminUserService.deleteUser(userId, currentAdminId);
     redirectAttributes.addFlashAttribute("successMessage", "사용자가 삭제되었습니다.");
-    return "redirect:/admin/users/" + userId;
+    return "redirect:/jidogam-admin/users/" + userId;
   }
 
   @PostMapping("/{userId}/restore")
   public String userRestore(@PathVariable UUID userId, RedirectAttributes redirectAttributes) {
     adminUserService.restoreUser(userId);
     redirectAttributes.addFlashAttribute("successMessage", "사용자가 복구되었습니다.");
-    return "redirect:/admin/users/" + userId;
+    return "redirect:/jidogam-admin/users/" + userId;
   }
 }

--- a/src/main/java/region/jidogam/domain/admin/controller/AdminUserController.java
+++ b/src/main/java/region/jidogam/domain/admin/controller/AdminUserController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import region.jidogam.common.annotation.CurrentUserId;
 import region.jidogam.domain.admin.dto.AdminUserResponse;
 import region.jidogam.domain.admin.dto.AdminUserSearchRequest;
 import region.jidogam.domain.admin.dto.AdminUserUpdateRequest;
@@ -61,19 +62,23 @@ public class AdminUserController {
   @PostMapping("/{userId}/edit")
   public String userUpdate(
       @PathVariable UUID userId,
+      @CurrentUserId UUID currentAdminId,
       @RequestParam(value = "nickname", required = false) String nickname,
       @RequestParam(value = "role", required = false) User.Role role,
       RedirectAttributes redirectAttributes) {
 
     AdminUserUpdateRequest request = new AdminUserUpdateRequest(nickname, role);
-    adminUserService.updateUser(userId, request);
+    adminUserService.updateUser(userId, request, currentAdminId);
     redirectAttributes.addFlashAttribute("successMessage", "사용자 정보가 수정되었습니다.");
     return "redirect:/admin/users/" + userId;
   }
 
   @PostMapping("/{userId}/delete")
-  public String userDelete(@PathVariable UUID userId, RedirectAttributes redirectAttributes) {
-    adminUserService.deleteUser(userId);
+  public String userDelete(
+      @PathVariable UUID userId,
+      @CurrentUserId UUID currentAdminId,
+      RedirectAttributes redirectAttributes) {
+    adminUserService.deleteUser(userId, currentAdminId);
     redirectAttributes.addFlashAttribute("successMessage", "사용자가 삭제되었습니다.");
     return "redirect:/admin/users/" + userId;
   }

--- a/src/main/java/region/jidogam/domain/admin/dto/AdminLoginRequest.java
+++ b/src/main/java/region/jidogam/domain/admin/dto/AdminLoginRequest.java
@@ -1,0 +1,8 @@
+package region.jidogam.domain.admin.dto;
+
+public record AdminLoginRequest(
+    String email,
+    String password
+) {
+
+}

--- a/src/main/java/region/jidogam/domain/admin/dto/AdminUserResponse.java
+++ b/src/main/java/region/jidogam/domain/admin/dto/AdminUserResponse.java
@@ -1,0 +1,36 @@
+package region.jidogam.domain.admin.dto;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.Builder;
+import region.jidogam.domain.user.entity.User;
+
+@Builder
+public record AdminUserResponse(
+    UUID id,
+    String email,
+    String nickname,
+    String profileImageUrl,
+    Long exp,
+    User.Role role,
+    LocalDateTime createdAt,
+    LocalDateTime updatedAt,
+    LocalDateTime deletedAt,
+    boolean deleted
+) {
+
+  public static AdminUserResponse from(User user) {
+    return AdminUserResponse.builder()
+        .id(user.getId())
+        .email(user.getEmail())
+        .nickname(user.getNickname())
+        .profileImageUrl(user.getProfileImageUrl())
+        .exp(user.getExp())
+        .role(user.getRole())
+        .createdAt(user.getCreatedAt())
+        .updatedAt(user.getUpdatedAt())
+        .deletedAt(user.getDeletedAt())
+        .deleted(user.isDeleted())
+        .build();
+  }
+}

--- a/src/main/java/region/jidogam/domain/admin/dto/AdminUserSearchRequest.java
+++ b/src/main/java/region/jidogam/domain/admin/dto/AdminUserSearchRequest.java
@@ -1,0 +1,32 @@
+package region.jidogam.domain.admin.dto;
+
+import region.jidogam.domain.user.entity.User;
+
+public record AdminUserSearchRequest(
+    String keyword,
+    User.Role role,
+    Boolean deleted,
+    int page,
+    int size
+) {
+
+  public AdminUserSearchRequest {
+    if (page < 0) {
+      page = 0;
+    }
+    if (size <= 0 || size > 100) {
+      size = 20;
+    }
+  }
+
+  public static AdminUserSearchRequest of(String keyword, User.Role role, Boolean deleted,
+      Integer page, Integer size) {
+    return new AdminUserSearchRequest(
+        keyword,
+        role,
+        deleted,
+        page == null ? 0 : page,
+        size == null ? 20 : size
+    );
+  }
+}

--- a/src/main/java/region/jidogam/domain/admin/dto/AdminUserUpdateRequest.java
+++ b/src/main/java/region/jidogam/domain/admin/dto/AdminUserUpdateRequest.java
@@ -1,0 +1,10 @@
+package region.jidogam.domain.admin.dto;
+
+import region.jidogam.domain.user.entity.User;
+
+public record AdminUserUpdateRequest(
+    String nickname,
+    User.Role role
+) {
+
+}

--- a/src/main/java/region/jidogam/domain/admin/repository/AdminUserRepository.java
+++ b/src/main/java/region/jidogam/domain/admin/repository/AdminUserRepository.java
@@ -1,0 +1,10 @@
+package region.jidogam.domain.admin.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import region.jidogam.domain.user.entity.User;
+
+public interface AdminUserRepository {
+
+  Page<User> searchUsers(String keyword, User.Role role, Boolean deleted, Pageable pageable);
+}

--- a/src/main/java/region/jidogam/domain/admin/repository/AdminUserRepositoryImpl.java
+++ b/src/main/java/region/jidogam/domain/admin/repository/AdminUserRepositoryImpl.java
@@ -1,0 +1,60 @@
+package region.jidogam.domain.admin.repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+import region.jidogam.domain.user.entity.QUser;
+import region.jidogam.domain.user.entity.User;
+
+@Repository
+@RequiredArgsConstructor
+public class AdminUserRepositoryImpl implements AdminUserRepository {
+
+  private final JPAQueryFactory queryFactory;
+
+  @Override
+  public Page<User> searchUsers(String keyword, User.Role role, Boolean deleted,
+      Pageable pageable) {
+    QUser user = QUser.user;
+
+    BooleanBuilder builder = new BooleanBuilder();
+
+    if (keyword != null && !keyword.isBlank()) {
+      builder.and(
+          user.email.containsIgnoreCase(keyword)
+              .or(user.nickname.containsIgnoreCase(keyword))
+      );
+    }
+
+    if (role != null) {
+      builder.and(user.role.eq(role));
+    }
+
+    if (deleted != null) {
+      if (deleted) {
+        builder.and(user.deletedAt.isNotNull());
+      } else {
+        builder.and(user.deletedAt.isNull());
+      }
+    }
+
+    List<User> content = queryFactory.selectFrom(user)
+        .where(builder)
+        .orderBy(user.createdAt.desc())
+        .offset(pageable.getOffset())
+        .limit(pageable.getPageSize())
+        .fetch();
+
+    JPAQuery<Long> countQuery = queryFactory.select(user.count())
+        .from(user)
+        .where(builder);
+
+    return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+  }
+}

--- a/src/main/java/region/jidogam/domain/admin/service/AdminAuthService.java
+++ b/src/main/java/region/jidogam/domain/admin/service/AdminAuthService.java
@@ -1,0 +1,43 @@
+package region.jidogam.domain.admin.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import region.jidogam.domain.admin.dto.AdminLoginRequest;
+import region.jidogam.domain.user.entity.User;
+import region.jidogam.domain.user.entity.User.Role;
+import region.jidogam.domain.user.repository.UserRepository;
+import region.jidogam.infrastructure.jwt.JwtProvider;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AdminAuthService {
+
+  private final UserRepository userRepository;
+  private final PasswordEncoder passwordEncoder;
+  private final JwtProvider jwtProvider;
+
+  @Transactional(readOnly = true)
+  public String login(AdminLoginRequest request) {
+    User user = userRepository.findByEmail(request.email())
+        .orElseThrow(() -> new IllegalArgumentException("이메일 또는 비밀번호가 올바르지 않습니다."));
+
+    if (!passwordEncoder.matches(request.password(), user.getPassword())) {
+      throw new IllegalArgumentException("이메일 또는 비밀번호가 올바르지 않습니다.");
+    }
+
+    if (user.getRole() != Role.ADMIN) {
+      throw new IllegalArgumentException("관리자 권한이 없습니다.");
+    }
+
+    if (user.isDeleted()) {
+      throw new IllegalArgumentException("삭제된 계정입니다.");
+    }
+
+    log.info("관리자 로그인: email = {}", request.email());
+    return jwtProvider.generateAccessToken(user);
+  }
+}

--- a/src/main/java/region/jidogam/domain/admin/service/AdminUserService.java
+++ b/src/main/java/region/jidogam/domain/admin/service/AdminUserService.java
@@ -13,6 +13,7 @@ import region.jidogam.domain.admin.dto.AdminUserUpdateRequest;
 import region.jidogam.domain.admin.repository.AdminUserRepository;
 import region.jidogam.domain.user.entity.User;
 import region.jidogam.domain.user.exception.UserNicknameConflictException;
+import region.jidogam.domain.user.exception.UserNicknameLengthException;
 import region.jidogam.domain.user.exception.UserNotFoundException;
 import region.jidogam.domain.user.repository.UserRepository;
 
@@ -42,26 +43,33 @@ public class AdminUserService {
   }
 
   @Transactional
-  public AdminUserResponse updateUser(UUID userId, AdminUserUpdateRequest request) {
+  public AdminUserResponse updateUser(UUID userId, AdminUserUpdateRequest request,
+      UUID currentAdminId) {
     User user = userRepository.findById(userId)
         .orElseThrow(() -> UserNotFoundException.withId(userId));
 
     if (request.nickname() != null && !request.nickname().equals(user.getNickname())) {
-      if (userRepository.existsByNickname(request.nickname())) {
-        throw UserNicknameConflictException.withNickname(request.nickname());
-      }
+      validateNickname(request.nickname());
       user.changeNickname(request.nickname());
     }
 
     if (request.role() != null && request.role() != user.getRole()) {
+      if (userId.equals(currentAdminId)) {
+        throw new IllegalStateException("자기 자신의 역할은 변경할 수 없습니다.");
+      }
       user.changeRole(request.role());
     }
 
+    log.info("관리자에 의해 사용자 수정: userId = {}, adminId = {}", userId, currentAdminId);
     return AdminUserResponse.from(user);
   }
 
   @Transactional
-  public void deleteUser(UUID userId) {
+  public void deleteUser(UUID userId, UUID currentAdminId) {
+    if (userId.equals(currentAdminId)) {
+      throw new IllegalStateException("자기 자신을 삭제할 수 없습니다.");
+    }
+
     User user = userRepository.findById(userId)
         .orElseThrow(() -> UserNotFoundException.withId(userId));
 
@@ -71,7 +79,7 @@ public class AdminUserService {
     }
 
     user.softDelete();
-    log.info("관리자에 의해 사용자 삭제: userId = {}", userId);
+    log.info("관리자에 의해 사용자 삭제: userId = {}, adminId = {}", userId, currentAdminId);
   }
 
   @Transactional
@@ -86,5 +94,14 @@ public class AdminUserService {
 
     user.restore();
     log.info("관리자에 의해 사용자 복구: userId = {}", userId);
+  }
+
+  private void validateNickname(String nickname) {
+    if (nickname == null || nickname.isBlank() || nickname.length() < 2 || nickname.length() > 20) {
+      throw UserNicknameLengthException.withNickname(nickname);
+    }
+    if (userRepository.existsByNickname(nickname)) {
+      throw UserNicknameConflictException.withNickname(nickname);
+    }
   }
 }

--- a/src/main/java/region/jidogam/domain/admin/service/AdminUserService.java
+++ b/src/main/java/region/jidogam/domain/admin/service/AdminUserService.java
@@ -1,0 +1,90 @@
+package region.jidogam.domain.admin.service;
+
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import region.jidogam.domain.admin.dto.AdminUserResponse;
+import region.jidogam.domain.admin.dto.AdminUserSearchRequest;
+import region.jidogam.domain.admin.dto.AdminUserUpdateRequest;
+import region.jidogam.domain.admin.repository.AdminUserRepository;
+import region.jidogam.domain.user.entity.User;
+import region.jidogam.domain.user.exception.UserNicknameConflictException;
+import region.jidogam.domain.user.exception.UserNotFoundException;
+import region.jidogam.domain.user.repository.UserRepository;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AdminUserService {
+
+  private final UserRepository userRepository;
+  private final AdminUserRepository adminUserRepository;
+
+  @Transactional(readOnly = true)
+  public Page<AdminUserResponse> getUsers(AdminUserSearchRequest request) {
+    PageRequest pageable = PageRequest.of(request.page(), request.size());
+
+    return adminUserRepository.searchUsers(
+        request.keyword(), request.role(), request.deleted(), pageable
+    ).map(AdminUserResponse::from);
+  }
+
+  @Transactional(readOnly = true)
+  public AdminUserResponse getUser(UUID userId) {
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> UserNotFoundException.withId(userId));
+
+    return AdminUserResponse.from(user);
+  }
+
+  @Transactional
+  public AdminUserResponse updateUser(UUID userId, AdminUserUpdateRequest request) {
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> UserNotFoundException.withId(userId));
+
+    if (request.nickname() != null && !request.nickname().equals(user.getNickname())) {
+      if (userRepository.existsByNickname(request.nickname())) {
+        throw UserNicknameConflictException.withNickname(request.nickname());
+      }
+      user.changeNickname(request.nickname());
+    }
+
+    if (request.role() != null && request.role() != user.getRole()) {
+      user.changeRole(request.role());
+    }
+
+    return AdminUserResponse.from(user);
+  }
+
+  @Transactional
+  public void deleteUser(UUID userId) {
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> UserNotFoundException.withId(userId));
+
+    if (user.isDeleted()) {
+      log.warn("이미 삭제된 사용자입니다: userId = {}", userId);
+      return;
+    }
+
+    user.softDelete();
+    log.info("관리자에 의해 사용자 삭제: userId = {}", userId);
+  }
+
+  @Transactional
+  public void restoreUser(UUID userId) {
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> UserNotFoundException.withId(userId));
+
+    if (!user.isDeleted()) {
+      log.warn("삭제되지 않은 사용자입니다: userId = {}", userId);
+      return;
+    }
+
+    user.restore();
+    log.info("관리자에 의해 사용자 복구: userId = {}", userId);
+  }
+}

--- a/src/main/java/region/jidogam/domain/user/entity/User.java
+++ b/src/main/java/region/jidogam/domain/user/entity/User.java
@@ -57,6 +57,10 @@ public class User extends BaseUpdatableEntity {
       this.password = password;
   }
 
+  public void changeRole(Role role) {
+    this.role = role;
+  }
+
   public void changeProfileImage(String profileImageUrl) {
     this.profileImageUrl = profileImageUrl;   // null 허용
   }

--- a/src/main/java/region/jidogam/infrastructure/security/AdminUserDetailsService.java
+++ b/src/main/java/region/jidogam/infrastructure/security/AdminUserDetailsService.java
@@ -1,0 +1,33 @@
+package region.jidogam.infrastructure.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import region.jidogam.domain.user.entity.User;
+import region.jidogam.domain.user.entity.User.Role;
+import region.jidogam.domain.user.repository.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+public class AdminUserDetailsService implements UserDetailsService {
+
+  private final UserRepository userRepository;
+
+  @Override
+  public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+    User user = userRepository.findByEmail(email)
+        .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다: " + email));
+
+    if (user.getRole() != Role.ADMIN) {
+      throw new UsernameNotFoundException("관리자 권한이 없습니다.");
+    }
+
+    if (user.isDeleted()) {
+      throw new UsernameNotFoundException("삭제된 계정입니다.");
+    }
+
+    return new JidogamUserDetails(user);
+  }
+}

--- a/src/main/java/region/jidogam/infrastructure/security/JwtAuthenticationFilter.java
+++ b/src/main/java/region/jidogam/infrastructure/security/JwtAuthenticationFilter.java
@@ -2,6 +2,7 @@ package region.jidogam.infrastructure.security;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -20,6 +21,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
   private static final String AUTHORIZATION_HEADER = "Authorization";
   private static final String BEARER_PREFIX = "Bearer ";
+  private static final String ACCESS_TOKEN_COOKIE = "access_token";
 
   @Override
   protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
@@ -42,10 +44,22 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
   }
 
   private String extractToken(HttpServletRequest request) {
+    // 1. Authorization 헤더 우선
     String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
     if (bearerToken != null && bearerToken.startsWith(BEARER_PREFIX)) {
       return bearerToken.substring(BEARER_PREFIX.length());
     }
+
+    // 2. 쿠키 fallback (admin 페이지용)
+    Cookie[] cookies = request.getCookies();
+    if (cookies != null) {
+      for (Cookie cookie : cookies) {
+        if (ACCESS_TOKEN_COOKIE.equals(cookie.getName())) {
+          return cookie.getValue();
+        }
+      }
+    }
+
     return null;
   }
 }

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -3,3 +3,8 @@ spring:
     hibernate:
       ddl-auto: validate
 
+
+jidogam:
+  admin:
+    cookie:
+      secure: true

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -73,6 +73,8 @@ jidogam:
     email: ${ADMIN_EMAIL}
     password: ${ADMIN_PASSWORD}
     nickname: ${ADMIN_NICKNAME}
+    cookie:
+      secure: ${ADMIN_COOKIE_SECURE:false}
 
 jwt:
   secret: ${JWT_SECRET}

--- a/src/main/resources/static/css/admin.css
+++ b/src/main/resources/static/css/admin.css
@@ -266,3 +266,425 @@ body {
   font-weight: 700;
   color: var(--gray900);
 }
+
+/* ── Filter Bar ── */
+.filter-bar {
+  margin-bottom: 24px;
+}
+
+.filter-form {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.filter-input {
+  padding: 10px 16px;
+  border: 1px solid var(--gray300);
+  border-radius: 8px;
+  font-size: 14px;
+  font-family: inherit;
+  color: var(--gray900);
+  background: var(--gray0);
+  outline: none;
+  min-width: 240px;
+  transition: border-color 0.2s;
+}
+
+.filter-input:focus {
+  border-color: var(--primary300);
+  box-shadow: 0 0 0 3px rgba(162, 205, 32, 0.15);
+}
+
+.filter-input::placeholder {
+  color: var(--gray500);
+}
+
+.filter-select {
+  padding: 10px 16px;
+  border: 1px solid var(--gray300);
+  border-radius: 8px;
+  font-size: 14px;
+  font-family: inherit;
+  color: var(--gray900);
+  background: var(--gray0);
+  outline: none;
+  cursor: pointer;
+  transition: border-color 0.2s;
+}
+
+.filter-select:focus {
+  border-color: var(--primary300);
+}
+
+.btn-search {
+  padding: 10px 20px;
+  background: var(--primary300);
+  color: var(--gray0);
+  border: none;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  font-family: inherit;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.btn-search:hover {
+  background: var(--primary400);
+}
+
+.btn-reset {
+  padding: 10px 20px;
+  background: var(--gray0);
+  color: var(--gray700);
+  border: 1px solid var(--gray300);
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 500;
+  font-family: inherit;
+  text-decoration: none;
+  transition: all 0.2s;
+}
+
+.btn-reset:hover {
+  background: var(--gray50);
+  border-color: var(--gray400);
+}
+
+/* ── Data Table ── */
+.table-container {
+  background: var(--gray0);
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(38, 38, 36, 0.06);
+  overflow: hidden;
+  margin-bottom: 20px;
+}
+
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.data-table th {
+  padding: 14px 20px;
+  text-align: left;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--gray600);
+  background: var(--gray50);
+  border-bottom: 1px solid var(--gray300);
+}
+
+.data-table td {
+  padding: 14px 20px;
+  font-size: 14px;
+  color: var(--gray800);
+  border-bottom: 1px solid var(--gray200);
+}
+
+.data-table tr:last-child td {
+  border-bottom: none;
+}
+
+.data-table tr:hover {
+  background: var(--gray100);
+}
+
+.data-table .row-deleted {
+  opacity: 0.55;
+}
+
+.empty-message {
+  text-align: center;
+  color: var(--gray500);
+  padding: 40px 20px !important;
+}
+
+/* ── Badges ── */
+.badge {
+  display: inline-block;
+  padding: 4px 10px;
+  border-radius: 12px;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.badge-admin {
+  background: var(--primary50);
+  color: var(--primary400);
+}
+
+.badge-user {
+  background: var(--gray200);
+  color: var(--gray700);
+}
+
+/* ── Status ── */
+.status-active {
+  color: var(--primary400);
+  font-weight: 500;
+  font-size: 13px;
+}
+
+.status-deleted {
+  color: var(--red300);
+  font-weight: 500;
+  font-size: 13px;
+}
+
+/* ── Action Buttons ── */
+.btn-detail {
+  padding: 6px 14px;
+  background: var(--gray0);
+  color: var(--gray700);
+  border: 1px solid var(--gray300);
+  border-radius: 6px;
+  font-size: 13px;
+  font-family: inherit;
+  text-decoration: none;
+  transition: all 0.2s;
+}
+
+.btn-detail:hover {
+  background: var(--gray50);
+  border-color: var(--gray400);
+}
+
+/* ── Pagination ── */
+.pagination {
+  display: flex;
+  justify-content: center;
+  gap: 4px;
+  margin-bottom: 12px;
+}
+
+.page-link {
+  padding: 8px 14px;
+  border: 1px solid var(--gray300);
+  border-radius: 6px;
+  font-size: 14px;
+  color: var(--gray700);
+  text-decoration: none;
+  transition: all 0.2s;
+}
+
+.page-link:hover {
+  background: var(--gray100);
+  border-color: var(--gray400);
+}
+
+.page-link.active {
+  background: var(--primary300);
+  color: var(--gray0);
+  border-color: var(--primary300);
+}
+
+.pagination-info {
+  text-align: center;
+  font-size: 13px;
+  color: var(--gray600);
+}
+
+/* ── Page Header ── */
+.page-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 24px;
+}
+
+.page-header h2 {
+  margin-bottom: 0;
+}
+
+.btn-back {
+  padding: 8px 16px;
+  color: var(--gray700);
+  text-decoration: none;
+  font-size: 14px;
+  font-weight: 500;
+  transition: color 0.2s;
+}
+
+.btn-back:hover {
+  color: var(--gray900);
+}
+
+/* ── Detail Card ── */
+.detail-card {
+  background: var(--gray0);
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(38, 38, 36, 0.06);
+  padding: 8px 0;
+  margin-bottom: 24px;
+}
+
+.detail-row {
+  display: flex;
+  padding: 14px 28px;
+  border-bottom: 1px solid var(--gray200);
+}
+
+.detail-row:last-child {
+  border-bottom: none;
+}
+
+.detail-label {
+  width: 140px;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--gray600);
+  flex-shrink: 0;
+}
+
+.detail-value {
+  font-size: 14px;
+  color: var(--gray900);
+  word-break: break-all;
+}
+
+.profile-img {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 2px solid var(--gray200);
+}
+
+/* ── Action Buttons (Detail) ── */
+.action-buttons {
+  display: flex;
+  gap: 12px;
+}
+
+.btn-edit {
+  padding: 10px 24px;
+  background: var(--primary300);
+  color: var(--gray0);
+  border: none;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  font-family: inherit;
+  text-decoration: none;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.btn-edit:hover {
+  background: var(--primary400);
+}
+
+.btn-delete {
+  padding: 10px 24px;
+  background: var(--gray0);
+  color: var(--red300);
+  border: 1px solid var(--red200);
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  font-family: inherit;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.btn-delete:hover {
+  background: var(--red50);
+}
+
+.btn-restore {
+  padding: 10px 24px;
+  background: var(--gray0);
+  color: var(--primary400);
+  border: 1px solid var(--primary200);
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  font-family: inherit;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.btn-restore:hover {
+  background: var(--primary50);
+}
+
+/* ── Form Card ── */
+.form-card {
+  background: var(--gray0);
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(38, 38, 36, 0.06);
+  padding: 32px;
+  max-width: 560px;
+}
+
+.form-input {
+  width: 100%;
+  padding: 12px 16px;
+  border: 1px solid var(--gray300);
+  border-radius: 8px;
+  font-size: 15px;
+  font-family: inherit;
+  color: var(--gray900);
+  background: var(--gray0);
+  transition: border-color 0.2s;
+  outline: none;
+}
+
+.form-input:focus {
+  border-color: var(--primary300);
+  box-shadow: 0 0 0 3px rgba(162, 205, 32, 0.15);
+}
+
+.form-input:disabled {
+  background: var(--gray100);
+  color: var(--gray500);
+  cursor: not-allowed;
+}
+
+select.form-input {
+  cursor: pointer;
+}
+
+.form-actions {
+  display: flex;
+  gap: 12px;
+  margin-top: 24px;
+}
+
+.btn-save {
+  padding: 12px 32px;
+  background: var(--primary300);
+  color: var(--gray0);
+  border: none;
+  border-radius: 8px;
+  font-size: 15px;
+  font-weight: 600;
+  font-family: inherit;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.btn-save:hover {
+  background: var(--primary400);
+}
+
+.btn-cancel {
+  padding: 12px 32px;
+  background: var(--gray0);
+  color: var(--gray700);
+  border: 1px solid var(--gray300);
+  border-radius: 8px;
+  font-size: 15px;
+  font-weight: 500;
+  font-family: inherit;
+  text-decoration: none;
+  transition: all 0.2s;
+}
+
+.btn-cancel:hover {
+  background: var(--gray50);
+  border-color: var(--gray400);
+}

--- a/src/main/resources/templates/admin/fragments/layout.html
+++ b/src/main/resources/templates/admin/fragments/layout.html
@@ -5,8 +5,8 @@
 <aside th:fragment="sidebar" class="sidebar">
   <div class="sidebar-logo">지도감 Admin</div>
   <ul class="sidebar-nav">
-    <li><a th:href="@{/admin/home}" th:classappend="${menu == 'home'} ? 'active'">홈</a></li>
-    <li><a th:href="@{/admin/users}" th:classappend="${menu == 'users'} ? 'active'">사용자 관리</a></li>
+    <li><a th:href="@{/jidogam-admin/home}" th:classappend="${menu == 'home'} ? 'active'">홈</a></li>
+    <li><a th:href="@{/jidogam-admin/users}" th:classappend="${menu == 'users'} ? 'active'">사용자 관리</a></li>
   </ul>
 </aside>
 
@@ -17,8 +17,8 @@
   </div>
   <script>
     async function adminLogout() {
-      await fetch('/admin/api/logout', { method: 'POST' });
-      location.href = '/admin/login';
+      await fetch('/jidogam-admin/api/logout', { method: 'POST' });
+      location.href = '/jidogam-admin/login';
     }
   </script>
 </header>

--- a/src/main/resources/templates/admin/fragments/layout.html
+++ b/src/main/resources/templates/admin/fragments/layout.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
-<html lang="ko" xmlns:th="http://www.thymeleaf.org"
-      xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
 
 <!-- Sidebar Fragment -->
 <aside th:fragment="sidebar" class="sidebar">
@@ -14,11 +13,14 @@
 <!-- Top Bar Fragment -->
 <header th:fragment="topbar" class="top-bar">
   <div class="admin-info">
-    <span class="admin-name" sec:authentication="name">관리자</span>
-    <form th:action="@{/admin/logout}" method="post" style="display:inline;">
-      <button type="submit" class="btn-logout">로그아웃</button>
-    </form>
+    <button type="button" class="btn-logout" onclick="adminLogout()">로그아웃</button>
   </div>
+  <script>
+    async function adminLogout() {
+      await fetch('/admin/api/logout', { method: 'POST' });
+      location.href = '/admin/login';
+    }
+  </script>
 </header>
 
 </html>

--- a/src/main/resources/templates/admin/fragments/layout.html
+++ b/src/main/resources/templates/admin/fragments/layout.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org"
+      xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
+
+<!-- Sidebar Fragment -->
+<aside th:fragment="sidebar" class="sidebar">
+  <div class="sidebar-logo">지도감 Admin</div>
+  <ul class="sidebar-nav">
+    <li><a th:href="@{/admin/home}" th:classappend="${menu == 'home'} ? 'active'">홈</a></li>
+    <li><a th:href="@{/admin/users}" th:classappend="${menu == 'users'} ? 'active'">사용자 관리</a></li>
+  </ul>
+</aside>
+
+<!-- Top Bar Fragment -->
+<header th:fragment="topbar" class="top-bar">
+  <div class="admin-info">
+    <span class="admin-name" sec:authentication="name">관리자</span>
+    <form th:action="@{/admin/logout}" method="post" style="display:inline;">
+      <button type="submit" class="btn-logout">로그아웃</button>
+    </form>
+  </div>
+</header>
+
+</html>

--- a/src/main/resources/templates/admin/home.html
+++ b/src/main/resources/templates/admin/home.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
-<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<html lang="ko" xmlns:th="http://www.thymeleaf.org"
+      xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -8,20 +9,10 @@
 </head>
 <body>
   <div class="admin-layout">
-    <aside class="sidebar">
-      <div class="sidebar-logo">지도감 Admin</div>
-      <ul class="sidebar-nav">
-        <li><a href="/jidogam-admin/home" class="active">홈</a></li>
-      </ul>
-    </aside>
+    <aside th:replace="~{admin/fragments/layout :: sidebar}" th:with="menu='home'"></aside>
 
     <div class="main-content">
-      <header class="top-bar">
-        <div class="admin-info">
-          <span class="admin-name" id="adminName">관리자</span>
-          <button type="button" class="btn-logout" id="logoutBtn">로그아웃</button>
-        </div>
-      </header>
+      <header th:replace="~{admin/fragments/layout :: topbar}"></header>
 
       <main class="content-area">
         <h2>대시보드</h2>
@@ -34,18 +25,5 @@
       </main>
     </div>
   </div>
-
-  <script>
-    const token = localStorage.getItem('adminToken');
-
-    if (!token) {
-      location.href = '/jidogam-admin/login';
-    }
-
-    document.getElementById('logoutBtn').addEventListener('click', () => {
-      localStorage.removeItem('adminToken');
-      location.href = '/jidogam-admin/login';
-    });
-  </script>
 </body>
 </html>

--- a/src/main/resources/templates/admin/login.html
+++ b/src/main/resources/templates/admin/login.html
@@ -31,11 +31,6 @@
   </div>
 
   <script>
-    // 이미 로그인 상태면 홈으로 이동
-    if (localStorage.getItem('adminToken')) {
-      location.href = '/jidogam-admin/home';
-    }
-
     document.getElementById('loginForm').addEventListener('submit', async (e) => {
       e.preventDefault();
 
@@ -46,22 +41,20 @@
       const password = document.getElementById('password').value;
 
       try {
-        const res = await fetch('/api/auth/login', {
+        const res = await fetch('/admin/api/login', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ email, password })
         });
 
         if (!res.ok) {
-          const data = await res.json();
-          errorDiv.textContent = data.message || '이메일 또는 비밀번호가 올바르지 않습니다.';
+          const data = await res.json().catch(() => null);
+          errorDiv.textContent = (data && data.message) || '이메일 또는 비밀번호가 올바르지 않습니다.';
           errorDiv.style.display = 'block';
           return;
         }
 
-        const data = await res.json();
-        localStorage.setItem('adminToken', data.accessToken);
-        location.href = '/jidogam-admin/home';
+        location.href = '/admin/home';
       } catch (err) {
         errorDiv.textContent = '서버 연결에 실패했습니다.';
         errorDiv.style.display = 'block';

--- a/src/main/resources/templates/admin/login.html
+++ b/src/main/resources/templates/admin/login.html
@@ -41,7 +41,7 @@
       const password = document.getElementById('password').value;
 
       try {
-        const res = await fetch('/admin/api/login', {
+        const res = await fetch('/jidogam-admin/api/login', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ email, password })
@@ -54,7 +54,7 @@
           return;
         }
 
-        location.href = '/admin/home';
+        location.href = '/jidogam-admin/home';
       } catch (err) {
         errorDiv.textContent = '서버 연결에 실패했습니다.';
         errorDiv.style.display = 'block';

--- a/src/main/resources/templates/admin/users/detail.html
+++ b/src/main/resources/templates/admin/users/detail.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org"
+      xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>사용자 상세 - 지도감 관리자</title>
+  <link rel="stylesheet" th:href="@{/css/admin.css}">
+</head>
+<body>
+  <div class="admin-layout">
+    <aside th:replace="~{admin/fragments/layout :: sidebar}" th:with="menu='users'"></aside>
+
+    <div class="main-content">
+      <header th:replace="~{admin/fragments/layout :: topbar}"></header>
+
+      <main class="content-area">
+        <div class="page-header">
+          <h2>사용자 상세</h2>
+          <a th:href="@{/admin/users}" class="btn-back">&larr; 목록으로</a>
+        </div>
+
+        <!-- Success Message -->
+        <div th:if="${successMessage}" class="message-info" th:text="${successMessage}"></div>
+
+        <div class="detail-card">
+          <div class="detail-row">
+            <div class="detail-label">ID</div>
+            <div class="detail-value" th:text="${user.id()}"></div>
+          </div>
+          <div class="detail-row">
+            <div class="detail-label">이메일</div>
+            <div class="detail-value" th:text="${user.email()}"></div>
+          </div>
+          <div class="detail-row">
+            <div class="detail-label">닉네임</div>
+            <div class="detail-value" th:text="${user.nickname()}"></div>
+          </div>
+          <div class="detail-row">
+            <div class="detail-label">프로필 이미지</div>
+            <div class="detail-value">
+              <img th:if="${user.profileImageUrl()}" th:src="${user.profileImageUrl()}"
+                   alt="프로필" class="profile-img">
+              <span th:if="${user.profileImageUrl() == null}">없음</span>
+            </div>
+          </div>
+          <div class="detail-row">
+            <div class="detail-label">역할</div>
+            <div class="detail-value">
+              <span class="badge" th:classappend="${user.role().name() == 'ADMIN'} ? 'badge-admin' : 'badge-user'"
+                    th:text="${user.role()}"></span>
+            </div>
+          </div>
+          <div class="detail-row">
+            <div class="detail-label">경험치</div>
+            <div class="detail-value" th:text="${user.exp()}"></div>
+          </div>
+          <div class="detail-row">
+            <div class="detail-label">상태</div>
+            <div class="detail-value">
+              <span th:if="${!user.deleted()}" class="status-active">활성</span>
+              <span th:if="${user.deleted()}" class="status-deleted">삭제됨</span>
+            </div>
+          </div>
+          <div class="detail-row">
+            <div class="detail-label">가입일</div>
+            <div class="detail-value" th:text="${#temporals.format(user.createdAt(), 'yyyy-MM-dd HH:mm:ss')}"></div>
+          </div>
+          <div class="detail-row">
+            <div class="detail-label">수정일</div>
+            <div class="detail-value" th:text="${user.updatedAt() != null ? #temporals.format(user.updatedAt(), 'yyyy-MM-dd HH:mm:ss') : '-'}"></div>
+          </div>
+          <div class="detail-row" th:if="${user.deleted()}">
+            <div class="detail-label">삭제일</div>
+            <div class="detail-value" th:text="${#temporals.format(user.deletedAt(), 'yyyy-MM-dd HH:mm:ss')}"></div>
+          </div>
+        </div>
+
+        <div class="action-buttons">
+          <a th:href="@{/admin/users/{id}/edit(id=${user.id()})}" class="btn-edit">수정</a>
+          <form th:if="${!user.deleted()}" th:action="@{/admin/users/{id}/delete(id=${user.id()})}"
+                method="post" style="display:inline;"
+                onsubmit="return confirm('정말 이 사용자를 삭제하시겠습니까?');">
+            <button type="submit" class="btn-delete">삭제</button>
+          </form>
+          <form th:if="${user.deleted()}" th:action="@{/admin/users/{id}/restore(id=${user.id()})}"
+                method="post" style="display:inline;"
+                onsubmit="return confirm('이 사용자를 복구하시겠습니까?');">
+            <button type="submit" class="btn-restore">복구</button>
+          </form>
+        </div>
+      </main>
+    </div>
+  </div>
+</body>
+</html>

--- a/src/main/resources/templates/admin/users/detail.html
+++ b/src/main/resources/templates/admin/users/detail.html
@@ -17,7 +17,7 @@
       <main class="content-area">
         <div class="page-header">
           <h2>사용자 상세</h2>
-          <a th:href="@{/admin/users}" class="btn-back">&larr; 목록으로</a>
+          <a th:href="@{/jidogam-admin/users}" class="btn-back">&larr; 목록으로</a>
         </div>
 
         <!-- Success Message -->
@@ -77,13 +77,13 @@
         </div>
 
         <div class="action-buttons">
-          <a th:href="@{/admin/users/{id}/edit(id=${user.id()})}" class="btn-edit">수정</a>
-          <form th:if="${!user.deleted()}" th:action="@{/admin/users/{id}/delete(id=${user.id()})}"
+          <a th:href="@{/jidogam-admin/users/{id}/edit(id=${user.id()})}" class="btn-edit">수정</a>
+          <form th:if="${!user.deleted()}" th:action="@{/jidogam-admin/users/{id}/delete(id=${user.id()})}"
                 method="post" style="display:inline;"
                 onsubmit="return confirm('정말 이 사용자를 삭제하시겠습니까?');">
             <button type="submit" class="btn-delete">삭제</button>
           </form>
-          <form th:if="${user.deleted()}" th:action="@{/admin/users/{id}/restore(id=${user.id()})}"
+          <form th:if="${user.deleted()}" th:action="@{/jidogam-admin/users/{id}/restore(id=${user.id()})}"
                 method="post" style="display:inline;"
                 onsubmit="return confirm('이 사용자를 복구하시겠습니까?');">
             <button type="submit" class="btn-restore">복구</button>

--- a/src/main/resources/templates/admin/users/edit.html
+++ b/src/main/resources/templates/admin/users/edit.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org"
+      xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>사용자 수정 - 지도감 관리자</title>
+  <link rel="stylesheet" th:href="@{/css/admin.css}">
+</head>
+<body>
+  <div class="admin-layout">
+    <aside th:replace="~{admin/fragments/layout :: sidebar}" th:with="menu='users'"></aside>
+
+    <div class="main-content">
+      <header th:replace="~{admin/fragments/layout :: topbar}"></header>
+
+      <main class="content-area">
+        <div class="page-header">
+          <h2>사용자 수정</h2>
+          <a th:href="@{/admin/users/{id}(id=${user.id()})}" class="btn-back">&larr; 상세로</a>
+        </div>
+
+        <div class="form-card">
+          <form th:action="@{/admin/users/{id}/edit(id=${user.id()})}" method="post">
+            <div class="form-group">
+              <label>이메일</label>
+              <input type="text" th:value="${user.email()}" disabled class="form-input">
+            </div>
+            <div class="form-group">
+              <label for="nickname">닉네임</label>
+              <input type="text" id="nickname" name="nickname" th:value="${user.nickname()}" class="form-input">
+            </div>
+            <div class="form-group">
+              <label for="role">역할</label>
+              <select id="role" name="role" class="form-input">
+                <option value="USER" th:selected="${user.role().name() == 'USER'}">USER</option>
+                <option value="ADMIN" th:selected="${user.role().name() == 'ADMIN'}">ADMIN</option>
+              </select>
+            </div>
+
+            <div class="form-actions">
+              <button type="submit" class="btn-save">저장</button>
+              <a th:href="@{/admin/users/{id}(id=${user.id()})}" class="btn-cancel">취소</a>
+            </div>
+          </form>
+        </div>
+      </main>
+    </div>
+  </div>
+</body>
+</html>

--- a/src/main/resources/templates/admin/users/edit.html
+++ b/src/main/resources/templates/admin/users/edit.html
@@ -17,11 +17,11 @@
       <main class="content-area">
         <div class="page-header">
           <h2>사용자 수정</h2>
-          <a th:href="@{/admin/users/{id}(id=${user.id()})}" class="btn-back">&larr; 상세로</a>
+          <a th:href="@{/jidogam-admin/users/{id}(id=${user.id()})}" class="btn-back">&larr; 상세로</a>
         </div>
 
         <div class="form-card">
-          <form th:action="@{/admin/users/{id}/edit(id=${user.id()})}" method="post">
+          <form th:action="@{/jidogam-admin/users/{id}/edit(id=${user.id()})}" method="post">
             <div class="form-group">
               <label>이메일</label>
               <input type="text" th:value="${user.email()}" disabled class="form-input">
@@ -40,7 +40,7 @@
 
             <div class="form-actions">
               <button type="submit" class="btn-save">저장</button>
-              <a th:href="@{/admin/users/{id}(id=${user.id()})}" class="btn-cancel">취소</a>
+              <a th:href="@{/jidogam-admin/users/{id}(id=${user.id()})}" class="btn-cancel">취소</a>
             </div>
           </form>
         </div>

--- a/src/main/resources/templates/admin/users/list.html
+++ b/src/main/resources/templates/admin/users/list.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org"
+      xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>사용자 관리 - 지도감 관리자</title>
+  <link rel="stylesheet" th:href="@{/css/admin.css}">
+</head>
+<body>
+  <div class="admin-layout">
+    <aside th:replace="~{admin/fragments/layout :: sidebar}" th:with="menu='users'"></aside>
+
+    <div class="main-content">
+      <header th:replace="~{admin/fragments/layout :: topbar}"></header>
+
+      <main class="content-area">
+        <h2>사용자 관리</h2>
+
+        <!-- Search & Filter -->
+        <div class="filter-bar">
+          <form th:action="@{/admin/users}" method="get" class="filter-form">
+            <input type="text" name="keyword" th:value="${keyword}"
+                   placeholder="이메일 또는 닉네임 검색" class="filter-input">
+            <select name="role" class="filter-select">
+              <option value="">전체 역할</option>
+              <option value="USER" th:selected="${role != null && role.name() == 'USER'}">USER</option>
+              <option value="ADMIN" th:selected="${role != null && role.name() == 'ADMIN'}">ADMIN</option>
+            </select>
+            <select name="deleted" class="filter-select">
+              <option value="">전체 상태</option>
+              <option value="false" th:selected="${deleted != null && !deleted}">활성</option>
+              <option value="true" th:selected="${deleted != null && deleted}">삭제됨</option>
+            </select>
+            <button type="submit" class="btn-search">검색</button>
+            <a th:href="@{/admin/users}" class="btn-reset">초기화</a>
+          </form>
+        </div>
+
+        <!-- User Table -->
+        <div class="table-container">
+          <table class="data-table">
+            <thead>
+              <tr>
+                <th>이메일</th>
+                <th>닉네임</th>
+                <th>역할</th>
+                <th>경험치</th>
+                <th>상태</th>
+                <th>가입일</th>
+                <th>관리</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr th:each="user : ${users.content}" th:classappend="${user.deleted()} ? 'row-deleted'">
+                <td th:text="${user.email()}"></td>
+                <td th:text="${user.nickname()}"></td>
+                <td>
+                  <span class="badge" th:classappend="${user.role().name() == 'ADMIN'} ? 'badge-admin' : 'badge-user'"
+                        th:text="${user.role()}"></span>
+                </td>
+                <td th:text="${user.exp()}"></td>
+                <td>
+                  <span th:if="${!user.deleted()}" class="status-active">활성</span>
+                  <span th:if="${user.deleted()}" class="status-deleted">삭제됨</span>
+                </td>
+                <td th:text="${#temporals.format(user.createdAt(), 'yyyy-MM-dd HH:mm')}"></td>
+                <td>
+                  <a th:href="@{/admin/users/{id}(id=${user.id()})}" class="btn-detail">상세</a>
+                </td>
+              </tr>
+              <tr th:if="${users.content.isEmpty()}">
+                <td colspan="7" class="empty-message">사용자가 없습니다.</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <!-- Pagination -->
+        <div class="pagination" th:if="${users.totalPages > 1}">
+          <a th:if="${users.number > 0}"
+             th:href="@{/admin/users(keyword=${keyword}, role=${role}, deleted=${deleted}, page=${users.number - 1}, size=${users.size})}"
+             class="page-link">&laquo; 이전</a>
+
+          <th:block th:each="i : ${#numbers.sequence(0, users.totalPages - 1)}">
+            <a th:if="${i == users.number}" class="page-link active" th:text="${i + 1}"></a>
+            <a th:if="${i != users.number}"
+               th:href="@{/admin/users(keyword=${keyword}, role=${role}, deleted=${deleted}, page=${i}, size=${users.size})}"
+               class="page-link" th:text="${i + 1}"></a>
+          </th:block>
+
+          <a th:if="${users.number < users.totalPages - 1}"
+             th:href="@{/admin/users(keyword=${keyword}, role=${role}, deleted=${deleted}, page=${users.number + 1}, size=${users.size})}"
+             class="page-link">다음 &raquo;</a>
+        </div>
+
+        <div class="pagination-info">
+          <span th:text="'총 ' + ${users.totalElements} + '명'"></span>
+        </div>
+      </main>
+    </div>
+  </div>
+</body>
+</html>

--- a/src/main/resources/templates/admin/users/list.html
+++ b/src/main/resources/templates/admin/users/list.html
@@ -19,7 +19,7 @@
 
         <!-- Search & Filter -->
         <div class="filter-bar">
-          <form th:action="@{/admin/users}" method="get" class="filter-form">
+          <form th:action="@{/jidogam-admin/users}" method="get" class="filter-form">
             <input type="text" name="keyword" th:value="${keyword}"
                    placeholder="이메일 또는 닉네임 검색" class="filter-input">
             <select name="role" class="filter-select">
@@ -33,7 +33,7 @@
               <option value="true" th:selected="${deleted != null && deleted}">삭제됨</option>
             </select>
             <button type="submit" class="btn-search">검색</button>
-            <a th:href="@{/admin/users}" class="btn-reset">초기화</a>
+            <a th:href="@{/jidogam-admin/users}" class="btn-reset">초기화</a>
           </form>
         </div>
 
@@ -66,7 +66,7 @@
                 </td>
                 <td th:text="${#temporals.format(user.createdAt(), 'yyyy-MM-dd HH:mm')}"></td>
                 <td>
-                  <a th:href="@{/admin/users/{id}(id=${user.id()})}" class="btn-detail">상세</a>
+                  <a th:href="@{/jidogam-admin/users/{id}(id=${user.id()})}" class="btn-detail">상세</a>
                 </td>
               </tr>
               <tr th:if="${users.content.isEmpty()}">
@@ -79,18 +79,18 @@
         <!-- Pagination -->
         <div class="pagination" th:if="${users.totalPages > 1}">
           <a th:if="${users.number > 0}"
-             th:href="@{/admin/users(keyword=${keyword}, role=${role}, deleted=${deleted}, page=${users.number - 1}, size=${users.size})}"
+             th:href="@{/jidogam-admin/users(keyword=${keyword}, role=${role}, deleted=${deleted}, page=${users.number - 1}, size=${users.size})}"
              class="page-link">&laquo; 이전</a>
 
           <th:block th:each="i : ${#numbers.sequence(0, users.totalPages - 1)}">
             <a th:if="${i == users.number}" class="page-link active" th:text="${i + 1}"></a>
             <a th:if="${i != users.number}"
-               th:href="@{/admin/users(keyword=${keyword}, role=${role}, deleted=${deleted}, page=${i}, size=${users.size})}"
+               th:href="@{/jidogam-admin/users(keyword=${keyword}, role=${role}, deleted=${deleted}, page=${i}, size=${users.size})}"
                class="page-link" th:text="${i + 1}"></a>
           </th:block>
 
           <a th:if="${users.number < users.totalPages - 1}"
-             th:href="@{/admin/users(keyword=${keyword}, role=${role}, deleted=${deleted}, page=${users.number + 1}, size=${users.size})}"
+             th:href="@{/jidogam-admin/users(keyword=${keyword}, role=${role}, deleted=${deleted}, page=${users.number + 1}, size=${users.size})}"
              class="page-link">다음 &raquo;</a>
         </div>
 

--- a/src/test/java/region/jidogam/domain/admin/service/AdminUserServiceTest.java
+++ b/src/test/java/region/jidogam/domain/admin/service/AdminUserServiceTest.java
@@ -53,13 +53,12 @@ class AdminUserServiceTest {
   }
 
   @Nested
-  @DisplayName("getUsers 메서드")
+  @DisplayName("getUsers")
   class GetUsers {
 
     @Test
     @DisplayName("검색 조건으로 사용자 목록을 조회한다")
     void returnsPagedUsers() {
-      // given
       AdminUserSearchRequest request = AdminUserSearchRequest.of(null, null, null, 0, 20);
       User user = createUser("test@test.com", "tester", Role.USER);
       Page<User> userPage = new PageImpl<>(List.of(user));
@@ -67,10 +66,8 @@ class AdminUserServiceTest {
       when(adminUserRepository.searchUsers(any(), any(), any(), any(Pageable.class)))
           .thenReturn(userPage);
 
-      // when
       Page<AdminUserResponse> result = adminUserService.getUsers(request);
 
-      // then
       assertThat(result.getContent()).hasSize(1);
       assertThat(result.getContent().get(0).email()).isEqualTo("test@test.com");
     }
@@ -78,38 +75,32 @@ class AdminUserServiceTest {
     @Test
     @DisplayName("키워드로 필터링하여 조회한다")
     void filtersWithKeyword() {
-      // given
       AdminUserSearchRequest request = AdminUserSearchRequest.of("test", null, null, 0, 20);
       Page<User> emptyPage = new PageImpl<>(List.of());
 
       when(adminUserRepository.searchUsers(eq("test"), any(), any(), any(Pageable.class)))
           .thenReturn(emptyPage);
 
-      // when
       Page<AdminUserResponse> result = adminUserService.getUsers(request);
 
-      // then
       assertThat(result.getContent()).isEmpty();
       verify(adminUserRepository).searchUsers(eq("test"), any(), any(), any(Pageable.class));
     }
   }
 
   @Nested
-  @DisplayName("getUser 메서드")
+  @DisplayName("getUser")
   class GetUser {
 
     @Test
     @DisplayName("사용자 ID로 상세 정보를 조회한다")
     void returnsUserDetail() {
-      // given
       UUID userId = UUID.randomUUID();
       User user = createUser("test@test.com", "tester", Role.USER);
       when(userRepository.findById(userId)).thenReturn(Optional.of(user));
 
-      // when
       AdminUserResponse result = adminUserService.getUser(userId);
 
-      // then
       assertThat(result.email()).isEqualTo("test@test.com");
       assertThat(result.nickname()).isEqualTo("tester");
     }
@@ -117,121 +108,132 @@ class AdminUserServiceTest {
     @Test
     @DisplayName("존재하지 않는 사용자 조회 시 예외가 발생한다")
     void throwsWhenUserNotFound() {
-      // given
       UUID userId = UUID.randomUUID();
       when(userRepository.findById(userId)).thenReturn(Optional.empty());
 
-      // when & then
       assertThatThrownBy(() -> adminUserService.getUser(userId))
           .isInstanceOf(UserNotFoundException.class);
     }
   }
 
   @Nested
-  @DisplayName("updateUser 메서드")
+  @DisplayName("updateUser")
   class UpdateUser {
 
     @Test
     @DisplayName("닉네임을 변경한다")
     void updatesNickname() {
-      // given
       UUID userId = UUID.randomUUID();
+      UUID adminId = UUID.randomUUID();
       User user = createUser("test@test.com", "oldNick", Role.USER);
       when(userRepository.findById(userId)).thenReturn(Optional.of(user));
       when(userRepository.existsByNickname("newNick")).thenReturn(false);
 
       AdminUserUpdateRequest request = new AdminUserUpdateRequest("newNick", null);
 
-      // when
-      AdminUserResponse result = adminUserService.updateUser(userId, request);
+      AdminUserResponse result = adminUserService.updateUser(userId, request, adminId);
 
-      // then
       assertThat(result.nickname()).isEqualTo("newNick");
     }
 
     @Test
     @DisplayName("역할을 변경한다")
     void updatesRole() {
-      // given
       UUID userId = UUID.randomUUID();
+      UUID adminId = UUID.randomUUID();
       User user = createUser("test@test.com", "tester", Role.USER);
       when(userRepository.findById(userId)).thenReturn(Optional.of(user));
 
       AdminUserUpdateRequest request = new AdminUserUpdateRequest(null, Role.ADMIN);
 
-      // when
-      AdminUserResponse result = adminUserService.updateUser(userId, request);
+      AdminUserResponse result = adminUserService.updateUser(userId, request, adminId);
 
-      // then
       assertThat(result.role()).isEqualTo(Role.ADMIN);
     }
 
     @Test
     @DisplayName("중복 닉네임으로 변경 시 예외가 발생한다")
     void throwsOnDuplicateNickname() {
-      // given
       UUID userId = UUID.randomUUID();
+      UUID adminId = UUID.randomUUID();
       User user = createUser("test@test.com", "oldNick", Role.USER);
       when(userRepository.findById(userId)).thenReturn(Optional.of(user));
       when(userRepository.existsByNickname("dupNick")).thenReturn(true);
 
       AdminUserUpdateRequest request = new AdminUserUpdateRequest("dupNick", null);
 
-      // when & then
-      assertThatThrownBy(() -> adminUserService.updateUser(userId, request))
+      assertThatThrownBy(() -> adminUserService.updateUser(userId, request, adminId))
           .isInstanceOf(UserNicknameConflictException.class);
+    }
+
+    @Test
+    @DisplayName("자기 자신의 역할은 변경할 수 없다")
+    void throwsOnSelfRoleChange() {
+      UUID userId = UUID.randomUUID();
+      User user = createUser("admin@test.com", "admin", Role.ADMIN);
+      when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+      AdminUserUpdateRequest request = new AdminUserUpdateRequest(null, Role.USER);
+
+      assertThatThrownBy(() -> adminUserService.updateUser(userId, request, userId))
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessageContaining("자기 자신");
     }
   }
 
   @Nested
-  @DisplayName("deleteUser 메서드")
+  @DisplayName("deleteUser")
   class DeleteUser {
 
     @Test
     @DisplayName("사용자를 소프트 삭제한다")
     void softDeletesUser() {
-      // given
       UUID userId = UUID.randomUUID();
+      UUID adminId = UUID.randomUUID();
       User user = createUser("test@test.com", "tester", Role.USER);
       when(userRepository.findById(userId)).thenReturn(Optional.of(user));
 
-      // when
-      adminUserService.deleteUser(userId);
+      adminUserService.deleteUser(userId, adminId);
 
-      // then
       assertThat(user.isDeleted()).isTrue();
     }
 
     @Test
     @DisplayName("존재하지 않는 사용자 삭제 시 예외가 발생한다")
     void throwsWhenUserNotFound() {
-      // given
       UUID userId = UUID.randomUUID();
+      UUID adminId = UUID.randomUUID();
       when(userRepository.findById(userId)).thenReturn(Optional.empty());
 
-      // when & then
-      assertThatThrownBy(() -> adminUserService.deleteUser(userId))
+      assertThatThrownBy(() -> adminUserService.deleteUser(userId, adminId))
           .isInstanceOf(UserNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("자기 자신을 삭제할 수 없다")
+    void throwsOnSelfDelete() {
+      UUID userId = UUID.randomUUID();
+
+      assertThatThrownBy(() -> adminUserService.deleteUser(userId, userId))
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessageContaining("자기 자신");
     }
   }
 
   @Nested
-  @DisplayName("restoreUser 메서드")
+  @DisplayName("restoreUser")
   class RestoreUser {
 
     @Test
     @DisplayName("삭제된 사용자를 복구한다")
     void restoresDeletedUser() {
-      // given
       UUID userId = UUID.randomUUID();
       User user = createUser("test@test.com", "tester", Role.USER);
       user.softDelete();
       when(userRepository.findById(userId)).thenReturn(Optional.of(user));
 
-      // when
       adminUserService.restoreUser(userId);
 
-      // then
       assertThat(user.isDeleted()).isFalse();
     }
   }

--- a/src/test/java/region/jidogam/domain/admin/service/AdminUserServiceTest.java
+++ b/src/test/java/region/jidogam/domain/admin/service/AdminUserServiceTest.java
@@ -1,0 +1,238 @@
+package region.jidogam.domain.admin.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import region.jidogam.domain.admin.dto.AdminUserResponse;
+import region.jidogam.domain.admin.dto.AdminUserSearchRequest;
+import region.jidogam.domain.admin.dto.AdminUserUpdateRequest;
+import region.jidogam.domain.admin.repository.AdminUserRepository;
+import region.jidogam.domain.user.entity.User;
+import region.jidogam.domain.user.entity.User.Role;
+import region.jidogam.domain.user.exception.UserNicknameConflictException;
+import region.jidogam.domain.user.exception.UserNotFoundException;
+import region.jidogam.domain.user.repository.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AdminUserService 테스트")
+class AdminUserServiceTest {
+
+  @InjectMocks
+  private AdminUserService adminUserService;
+
+  @Mock
+  private UserRepository userRepository;
+
+  @Mock
+  private AdminUserRepository adminUserRepository;
+
+  private User createUser(String email, String nickname, Role role) {
+    return User.builder()
+        .email(email)
+        .nickname(nickname)
+        .password("encoded_password")
+        .role(role)
+        .build();
+  }
+
+  @Nested
+  @DisplayName("getUsers 메서드")
+  class GetUsers {
+
+    @Test
+    @DisplayName("검색 조건으로 사용자 목록을 조회한다")
+    void returnsPagedUsers() {
+      // given
+      AdminUserSearchRequest request = AdminUserSearchRequest.of(null, null, null, 0, 20);
+      User user = createUser("test@test.com", "tester", Role.USER);
+      Page<User> userPage = new PageImpl<>(List.of(user));
+
+      when(adminUserRepository.searchUsers(any(), any(), any(), any(Pageable.class)))
+          .thenReturn(userPage);
+
+      // when
+      Page<AdminUserResponse> result = adminUserService.getUsers(request);
+
+      // then
+      assertThat(result.getContent()).hasSize(1);
+      assertThat(result.getContent().get(0).email()).isEqualTo("test@test.com");
+    }
+
+    @Test
+    @DisplayName("키워드로 필터링하여 조회한다")
+    void filtersWithKeyword() {
+      // given
+      AdminUserSearchRequest request = AdminUserSearchRequest.of("test", null, null, 0, 20);
+      Page<User> emptyPage = new PageImpl<>(List.of());
+
+      when(adminUserRepository.searchUsers(eq("test"), any(), any(), any(Pageable.class)))
+          .thenReturn(emptyPage);
+
+      // when
+      Page<AdminUserResponse> result = adminUserService.getUsers(request);
+
+      // then
+      assertThat(result.getContent()).isEmpty();
+      verify(adminUserRepository).searchUsers(eq("test"), any(), any(), any(Pageable.class));
+    }
+  }
+
+  @Nested
+  @DisplayName("getUser 메서드")
+  class GetUser {
+
+    @Test
+    @DisplayName("사용자 ID로 상세 정보를 조회한다")
+    void returnsUserDetail() {
+      // given
+      UUID userId = UUID.randomUUID();
+      User user = createUser("test@test.com", "tester", Role.USER);
+      when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+      // when
+      AdminUserResponse result = adminUserService.getUser(userId);
+
+      // then
+      assertThat(result.email()).isEqualTo("test@test.com");
+      assertThat(result.nickname()).isEqualTo("tester");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 사용자 조회 시 예외가 발생한다")
+    void throwsWhenUserNotFound() {
+      // given
+      UUID userId = UUID.randomUUID();
+      when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+      // when & then
+      assertThatThrownBy(() -> adminUserService.getUser(userId))
+          .isInstanceOf(UserNotFoundException.class);
+    }
+  }
+
+  @Nested
+  @DisplayName("updateUser 메서드")
+  class UpdateUser {
+
+    @Test
+    @DisplayName("닉네임을 변경한다")
+    void updatesNickname() {
+      // given
+      UUID userId = UUID.randomUUID();
+      User user = createUser("test@test.com", "oldNick", Role.USER);
+      when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+      when(userRepository.existsByNickname("newNick")).thenReturn(false);
+
+      AdminUserUpdateRequest request = new AdminUserUpdateRequest("newNick", null);
+
+      // when
+      AdminUserResponse result = adminUserService.updateUser(userId, request);
+
+      // then
+      assertThat(result.nickname()).isEqualTo("newNick");
+    }
+
+    @Test
+    @DisplayName("역할을 변경한다")
+    void updatesRole() {
+      // given
+      UUID userId = UUID.randomUUID();
+      User user = createUser("test@test.com", "tester", Role.USER);
+      when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+      AdminUserUpdateRequest request = new AdminUserUpdateRequest(null, Role.ADMIN);
+
+      // when
+      AdminUserResponse result = adminUserService.updateUser(userId, request);
+
+      // then
+      assertThat(result.role()).isEqualTo(Role.ADMIN);
+    }
+
+    @Test
+    @DisplayName("중복 닉네임으로 변경 시 예외가 발생한다")
+    void throwsOnDuplicateNickname() {
+      // given
+      UUID userId = UUID.randomUUID();
+      User user = createUser("test@test.com", "oldNick", Role.USER);
+      when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+      when(userRepository.existsByNickname("dupNick")).thenReturn(true);
+
+      AdminUserUpdateRequest request = new AdminUserUpdateRequest("dupNick", null);
+
+      // when & then
+      assertThatThrownBy(() -> adminUserService.updateUser(userId, request))
+          .isInstanceOf(UserNicknameConflictException.class);
+    }
+  }
+
+  @Nested
+  @DisplayName("deleteUser 메서드")
+  class DeleteUser {
+
+    @Test
+    @DisplayName("사용자를 소프트 삭제한다")
+    void softDeletesUser() {
+      // given
+      UUID userId = UUID.randomUUID();
+      User user = createUser("test@test.com", "tester", Role.USER);
+      when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+      // when
+      adminUserService.deleteUser(userId);
+
+      // then
+      assertThat(user.isDeleted()).isTrue();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 사용자 삭제 시 예외가 발생한다")
+    void throwsWhenUserNotFound() {
+      // given
+      UUID userId = UUID.randomUUID();
+      when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+      // when & then
+      assertThatThrownBy(() -> adminUserService.deleteUser(userId))
+          .isInstanceOf(UserNotFoundException.class);
+    }
+  }
+
+  @Nested
+  @DisplayName("restoreUser 메서드")
+  class RestoreUser {
+
+    @Test
+    @DisplayName("삭제된 사용자를 복구한다")
+    void restoresDeletedUser() {
+      // given
+      UUID userId = UUID.randomUUID();
+      User user = createUser("test@test.com", "tester", Role.USER);
+      user.softDelete();
+      when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+      // when
+      adminUserService.restoreUser(userId);
+
+      // then
+      assertThat(user.isDeleted()).isFalse();
+    }
+  }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

- #163

## 📝 PR 유형

- [x] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug Fix)
- [ ] 코드 개선 (Refactoring)
- [ ] 문서 작업 (Documentation)
- [ ] 환경 설정 (Configuration)
- [ ] 기타 (Other)

## 📝작업 내용

> 어드민 사용자 관리 CRUD 및 JWT 쿠키 기반 인증 구현

### 1. 어드민 인증 (JWT 쿠키 방식)
- `/jidogam-admin/api/login` — 이메일/비밀번호 검증 후 `access_token` HttpOnly 쿠키 설정
- `/jidogam-admin/api/logout` — 쿠키 삭제
- `JwtAuthenticationFilter`에 쿠키 fallback 추가 (기존 Bearer 헤더 우선, 없으면 쿠키 확인)
- `SecurityConfig`에 admin filter chain 추가 (`/jidogam-admin/**` → `ROLE_ADMIN` 필요)
- 기존 API (`Authorization: Bearer`) 동작에 영향 없음

### 2. 사용자 관리 기능
- **전체 조회**: 키워드(이메일/닉네임), 역할, 삭제 상태 필터 + offset 페이지네이션 (QueryDSL)
- **상세 조회**: 사용자 전체 정보 표시 (ID, 이메일, 닉네임, 역할, 경험치, 상태, 가입일 등)
- **수정**: 닉네임 변경 (2~20자 검증, 중복 검사), 역할 변경 (USER/ADMIN)
- **삭제**: 소프트 삭제 (`deletedAt` 설정)
- **복구**: 삭제된 사용자 복구 (`deletedAt = null`)

### 3. 보안
- 자기 자신 삭제 방지 (admin이 본인 계정 삭제 불가)
- 자기 자신 역할 변경 방지 (admin이 본인을 USER로 강등 불가)
- 닉네임 입력 검증 (길이, 공백, 중복)
- HttpOnly + SameSite=Lax 쿠키로 XSS/CSRF 방어

### 4. UI (Thymeleaf)
- 사용자 목록 페이지 (검색 필터, 테이블, 페이지네이션)
- 사용자 상세 페이지 (삭제/복구 버튼)
- 사용자 수정 폼 (닉네임, 역할)
- 공통 레이아웃 프래그먼트 (사이드바 + 상단바) 분리
- 사이드바에 "사용자 관리" 메뉴 추가


### 5. 테스트 결과
- AdminUserServiceTest: **12/12 통과** (0 failures)
- 조회(4), 수정(4), 삭제(3), 복구(1)

## 스크린샷
> 사용자 관리 메인 페이지

<img width="1512" height="704" alt="image" src="https://github.com/user-attachments/assets/da21e3a0-8720-4a1b-a0cf-245124b94eff" />

<br><br>

>  사용자 검색어, 필터 검색

<img width="1507" height="732" alt="image" src="https://github.com/user-attachments/assets/eeb8659d-a7d5-46a2-bd25-d09deab369fa" />

<img width="1507" height="647" alt="image" src="https://github.com/user-attachments/assets/4d030903-d6e8-4cba-8605-b913a04f614a" />

<br><br>

> 사용자 수정

(닉네임 수정전)
<img width="1511" height="814" alt="image" src="https://github.com/user-attachments/assets/3e7b05e0-a065-4186-9ebd-5dc2fcf2b438" />

(수정 페이지)
<img width="1510" height="628" alt="image" src="https://github.com/user-attachments/assets/451269fa-0ab4-42e4-ab93-b20b33ae3b61" />

(닉네임 수정후)
<img width="1510" height="871" alt="image" src="https://github.com/user-attachments/assets/db4a6429-7a22-47a0-bb1e-d9de2c63676a" />


<br><br>

> 사용자 삭제

<img width="1507" height="866" alt="image" src="https://github.com/user-attachments/assets/754111c4-6855-4f15-a78c-1f30831182fe" />



## 💬리뷰 요구사항(선택)
- JWT를 HttpOnly 쿠키에 저장하는 방식이 적절한지 검토 부탁드립니다
- admin filter chain과 기존 api filter chain의 분리가 올바른지 확인 부탁드립니다!

## #️⃣닫을 이슈

close #163
