### PR TITLE
fix: RefreshToken 중복 저장으로 인한 로그인 실패 수정

### DIFF
--- a/src/main/java/region/jidogam/infrastructure/jwt/RefreshToken.java
+++ b/src/main/java/region/jidogam/infrastructure/jwt/RefreshToken.java
@@ -20,7 +20,7 @@ import region.jidogam.common.entity.BaseEntity;
 @Builder
 public class RefreshToken extends BaseEntity {
 
-  @Column(name = "user_id", nullable = false)
+  @Column(name = "user_id", nullable = false, unique = true)
   private UUID userId;
 
   @Column(name = "refresh_token", nullable = false, length = 512)

--- a/src/main/java/region/jidogam/infrastructure/jwt/RefreshTokenRepository.java
+++ b/src/main/java/region/jidogam/infrastructure/jwt/RefreshTokenRepository.java
@@ -13,7 +13,7 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, UUID
 
   Optional<RefreshToken> findByRefreshToken(String refreshToken);
 
-  @Modifying(clearAutomatically = true, flushAutomatically = true)
+  @Modifying
   @Query("DELETE FROM RefreshToken r WHERE r.userId = :userId")
   int deleteByUserId(@Param("userId") UUID userId);
 }

--- a/src/main/java/region/jidogam/infrastructure/jwt/RefreshTokenRepository.java
+++ b/src/main/java/region/jidogam/infrastructure/jwt/RefreshTokenRepository.java
@@ -3,10 +3,17 @@ package region.jidogam.infrastructure.jwt;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, UUID> {
 
   Optional<RefreshToken> findByUserId(UUID userId);
 
   Optional<RefreshToken> findByRefreshToken(String refreshToken);
+
+  @Modifying(clearAutomatically = true, flushAutomatically = true)
+  @Query("DELETE FROM RefreshToken r WHERE r.userId = :userId")
+  int deleteByUserId(@Param("userId") UUID userId);
 }

--- a/src/main/java/region/jidogam/infrastructure/jwt/RefreshTokenService.java
+++ b/src/main/java/region/jidogam/infrastructure/jwt/RefreshTokenService.java
@@ -2,7 +2,6 @@ package region.jidogam.infrastructure.jwt;
 
 import jakarta.security.auth.message.AuthException;
 import java.time.LocalDateTime;
-import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -88,9 +87,9 @@ public class RefreshTokenService {
   }
 
   private void deleteExistingToken(UUID userId) {
-    refreshTokenRepository.findByUserId(userId).ifPresent(token -> {
-      log.debug("기존 RefreshToken 삭제: userId={}", userId);
-      refreshTokenRepository.delete(token);
-    });
+    int deleted = refreshTokenRepository.deleteByUserId(userId);
+    if (deleted > 0) {
+      log.debug("기존 RefreshToken 삭제: userId={}, count={}", userId, deleted);
+    }
   }
 }

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -124,7 +124,7 @@ CREATE INDEX idx_place_coordinates ON places (y, x);
 CREATE TABLE refresh_tokens
 (
     id            UUID PRIMARY KEY,
-    user_id       UUID                     NOT NULL,
+    user_id       UUID                     NOT NULL UNIQUE,
     refresh_token TEXT                     NOT NULL,
     created_at    TIMESTAMP WITH TIME ZONE NOT NULL,
     expires_at    TIMESTAMP WITH TIME ZONE NOT NULL

--- a/src/test/java/region/jidogam/infrastructure/jwt/RefreshTokenServiceTest.java
+++ b/src/test/java/region/jidogam/infrastructure/jwt/RefreshTokenServiceTest.java
@@ -3,7 +3,6 @@ package region.jidogam.infrastructure.jwt;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -49,34 +48,6 @@ class RefreshTokenServiceTest {
       String refreshTokenString = "refreshToken";
       LocalDateTime expiresAt = LocalDateTime.now().plusDays(30);
 
-      when(refreshTokenRepository.findByUserId(userId)).thenReturn(Optional.empty());
-      when(jwtProvider.generateRefreshToken(user)).thenReturn(refreshTokenString);
-      when(jwtProvider.extractExpirationTime(refreshTokenString)).thenReturn(expiresAt);
-      when(user.getId()).thenReturn(userId);
-
-      //when 
-      RefreshToken refreshToken = refreshTokenService.create(user);
-
-      //then
-      assertNotNull(refreshToken);
-      assertEquals(userId, refreshToken.getUserId());
-      assertEquals(refreshTokenString, refreshToken.getRefreshToken());
-      assertEquals(expiresAt, refreshToken.getExpiresAt());
-
-      verify(refreshTokenRepository, times(1)).save(any(RefreshToken.class));
-    }
-
-    @Test
-    @DisplayName("이미 발급한 토큰이 있는 경우 삭제 후 성공")
-    void successWhenAlreadyExsitsRefreshToken() {
-      //given
-      UUID userId = UUID.randomUUID();
-      User user = mock(User.class);
-      RefreshToken mockRefreshToken = mock(RefreshToken.class);
-      String refreshTokenString = "refreshToken";
-      LocalDateTime expiresAt = LocalDateTime.now().plusDays(30);
-
-      when(refreshTokenRepository.findByUserId(userId)).thenReturn(Optional.of(mockRefreshToken));
       when(jwtProvider.generateRefreshToken(user)).thenReturn(refreshTokenString);
       when(jwtProvider.extractExpirationTime(refreshTokenString)).thenReturn(expiresAt);
       when(user.getId()).thenReturn(userId);
@@ -90,7 +61,34 @@ class RefreshTokenServiceTest {
       assertEquals(refreshTokenString, refreshToken.getRefreshToken());
       assertEquals(expiresAt, refreshToken.getExpiresAt());
 
-      verify(refreshTokenRepository, times(1)).delete(mockRefreshToken);
+      verify(refreshTokenRepository, times(1)).deleteByUserId(userId);
+      verify(refreshTokenRepository, times(1)).save(any(RefreshToken.class));
+    }
+
+    @Test
+    @DisplayName("이미 발급한 토큰이 있는 경우 삭제 후 성공")
+    void successWhenAlreadyExsitsRefreshToken() {
+      //given
+      UUID userId = UUID.randomUUID();
+      User user = mock(User.class);
+      String refreshTokenString = "refreshToken";
+      LocalDateTime expiresAt = LocalDateTime.now().plusDays(30);
+
+      when(refreshTokenRepository.deleteByUserId(userId)).thenReturn(1);
+      when(jwtProvider.generateRefreshToken(user)).thenReturn(refreshTokenString);
+      when(jwtProvider.extractExpirationTime(refreshTokenString)).thenReturn(expiresAt);
+      when(user.getId()).thenReturn(userId);
+
+      //when
+      RefreshToken refreshToken = refreshTokenService.create(user);
+
+      //then
+      assertNotNull(refreshToken);
+      assertEquals(userId, refreshToken.getUserId());
+      assertEquals(refreshTokenString, refreshToken.getRefreshToken());
+      assertEquals(expiresAt, refreshToken.getExpiresAt());
+
+      verify(refreshTokenRepository, times(1)).deleteByUserId(userId);
       verify(refreshTokenRepository, times(1)).save(any(RefreshToken.class));
     }
   }
@@ -105,17 +103,15 @@ class RefreshTokenServiceTest {
       //given
       UUID userId = UUID.randomUUID();
       User user = mock(User.class);
-      RefreshToken mockRefreshToken = mock(RefreshToken.class);
 
       when(user.getId()).thenReturn(userId);
-      when(refreshTokenRepository.findByUserId(userId)).thenReturn(Optional.of(mockRefreshToken));
+      when(refreshTokenRepository.deleteByUserId(userId)).thenReturn(1);
 
       //when
       refreshTokenService.delete(user);
 
       //then
-      verify(refreshTokenRepository, times(1)).delete(mockRefreshToken);
-
+      verify(refreshTokenRepository, times(1)).deleteByUserId(userId);
     }
 
     @Test
@@ -124,16 +120,14 @@ class RefreshTokenServiceTest {
       //given
       UUID userId = UUID.randomUUID();
       User user = mock(User.class);
-      RefreshToken mockRefreshToken = mock(RefreshToken.class);
 
       when(user.getId()).thenReturn(userId);
-      when(refreshTokenRepository.findByUserId(userId)).thenReturn(Optional.empty());
 
       //when
       refreshTokenService.delete(user);
 
       //then
-      verify(refreshTokenRepository, never()).delete(mockRefreshToken);
+      verify(refreshTokenRepository, times(1)).deleteByUserId(userId);
     }
 
   }
@@ -169,11 +163,7 @@ class RefreshTokenServiceTest {
       // 새 액세스 토큰 생성을 위한 모킹
       when(jwtProvider.generateAccessToken(user)).thenReturn("accessToken");
 
-      // create 메서드 내부에서 호출되는 메서드들을 위한 모킹
-      // 1. deleteExistingToken 호출 시
-      when(refreshTokenRepository.findByUserId(userId)).thenReturn(Optional.empty());
-
-      // 2. 새 리프레시 토큰 생성 시
+      // 새 리프레시 토큰 생성 시
       when(jwtProvider.generateRefreshToken(user)).thenReturn(newRefreshTokenString);
       when(jwtProvider.extractExpirationTime(newRefreshTokenString)).thenReturn(newExpiresAt);
       when(refreshTokenRepository.save(any(RefreshToken.class))).thenReturn(mockNewRefreshToken);


### PR DESCRIPTION
## #️⃣연관된 이슈

- #185

## 📝 PR 유형

<!-- 해당하는 유형에 'x'로 체크해주세요. -->

- [ ] 기능 추가 (Feature)
- [x] 버그 수정 (Bug Fix)
- [ ] 코드 개선 (Refactoring)
- [ ] 문서 작업 (Documentation)
- [ ] 환경 설정 (Configuration)
- [ ] 기타 (Other)

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요 (이미지 첨부 가능)

동시 로그인 요청이 들어올 때 같은 `user_id`로 `refresh_tokens` 행이 2개 이상 저장되어, 이후 로그인 시 `findByUserId` 호출에서 `NonUniqueResultException`이 발생하며 로그인 자체가 실패하던 문제를 수정했습니다.

### 원인

- `refresh_tokens.user_id`에 UNIQUE 제약이 없어 동시 트랜잭션의 race condition으로 중복 행이 적재됨
- `RefreshTokenRepository.findByUserId`가 `Optional<RefreshToken>`을 반환하기 때문에 다건 조회 시 `IncorrectResultSizeDataAccessException` 발생
- `deleteExistingToken`이 단건 select-then-delete 패턴이라 다건 케이스를 다루지 못함

<img width="1253" height="238" alt="image" src="https://github.com/user-attachments/assets/3c8f7c73-0840-4292-991a-b2d7d0284a73" />


### 변경 사항

- `RefreshToken` 엔티티: `userId` 컬럼에 `unique = true` 적용
- `schema.sql`: `refresh_tokens.user_id`에 `UNIQUE` 제약 추가
- `RefreshTokenRepository`: `@Modifying @Query` 기반 `deleteByUserId(UUID)` 추가 (`clearAutomatically`, `flushAutomatically` 옵션 포함)
- `RefreshTokenService.deleteExistingToken`: select-then-delete 패턴을 단일 DELETE 쿼리로 교체


```sql
-- 1. 중복 행 정리: user_id별 최신 1건만 남김
DELETE FROM refresh_tokens
WHERE id NOT IN (
  SELECT DISTINCT ON (user_id) id
  FROM refresh_tokens
  ORDER BY user_id, created_at DESC
);

-- 2. UNIQUE 제약 추가
ALTER TABLE refresh_tokens
  ADD CONSTRAINT uk_refresh_tokens_user_id UNIQUE (user_id);
```

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


## #️⃣닫을 이슈

<!-- 닫을 이슈 번호를 입력해주세요. -->

close #185
