### PR TITLE
fix: hidden 가이드북 조회 안되도록 조건 수정

### DIFF
--- a/src/main/java/region/jidogam/domain/guidebook/dto/GuidebookResponse.java
+++ b/src/main/java/region/jidogam/domain/guidebook/dto/GuidebookResponse.java
@@ -7,21 +7,22 @@ import lombok.Builder;
 @Builder
 public record GuidebookResponse(
     UUID gid,
+    Boolean isHidden,
     String title,
     String description,
     String thumbnailUrl,
     String mapImageUrl,
     String emoji,
     String color,
-    int exp,
+    Integer exp,
     LocalDateTime createdAt,
     LocalDateTime updatedAt,
     LocalDateTime publishedDate,
-    double score,
-    int participantCount,
-    int totalPlaceCount,
-    int visitedPlaceCount,
-    int reviewCount,
+    Double score,
+    Integer participantCount,
+    Integer totalPlaceCount,
+    Integer visitedPlaceCount,
+    Integer reviewCount,
     AuthorDto author,
     AreaRatioDto areaRatio
 ) {

--- a/src/main/java/region/jidogam/domain/guidebook/mapper/GuidebookMapper.java
+++ b/src/main/java/region/jidogam/domain/guidebook/mapper/GuidebookMapper.java
@@ -26,6 +26,7 @@ public class GuidebookMapper {
   public GuidebookResponse toResponse(Guidebook guidebook, int visitedPlaceCount) {
     return GuidebookResponse.builder()
         .gid(guidebook.getId())
+        .isHidden(Boolean.TRUE.equals(guidebook.getAdminHidden()))
         .title(guidebook.getTitle())
         .description(guidebook.getDescription())
         .thumbnailUrl(fileStorage.generateGetUrl(guidebook.getThumbnailUrl()))
@@ -43,6 +44,13 @@ public class GuidebookMapper {
         .reviewCount(guidebook.getRatingCount())
         .author(toAuthorDto(guidebook.getAuthor()))
         .areaRatio(toAreaRatioDto(guidebook.getAreaRatio()))
+        .build();
+  }
+
+  public GuidebookResponse toHiddenResponse(Guidebook guidebook) {
+    return GuidebookResponse.builder()
+        .gid(guidebook.getId())
+        .isHidden(true)
         .build();
   }
 

--- a/src/main/java/region/jidogam/domain/guidebook/repository/querydsl/GuidebookCondition.java
+++ b/src/main/java/region/jidogam/domain/guidebook/repository/querydsl/GuidebookCondition.java
@@ -33,6 +33,11 @@ public class GuidebookCondition {
     return guidebook.isPublished.eq(true);
   }
 
+  // 관리자 숨김 조건
+  public static BooleanExpression isNotHidden() {
+    return guidebook.adminHidden.eq(false);
+  }
+
   // 구독자 조건
   public static BooleanExpression participantCountLoe(Integer count) {
     return count != null ? guidebook.participantCount.loe(count) : null;

--- a/src/main/java/region/jidogam/domain/guidebook/repository/querydsl/GuidebookRepositoryCustomImpl.java
+++ b/src/main/java/region/jidogam/domain/guidebook/repository/querydsl/GuidebookRepositoryCustomImpl.java
@@ -51,6 +51,7 @@ public class GuidebookRepositoryCustomImpl implements GuidebookRepositoryCustom 
 
     where.and(GuidebookCondition.isNotDeleted());
     where.and(GuidebookCondition.isPublished());
+    where.and(GuidebookCondition.isNotHidden());
     where.and(GuidebookCondition.titleContains(keyword));
     where.and(GuidebookCondition.isLocalGuidebook(isLocal));
     where.and(GuidebookCursorCondition.buildGuidebookCursor(cursor, sortBy, direction));
@@ -77,7 +78,8 @@ public class GuidebookRepositoryCustomImpl implements GuidebookRepositoryCustom 
             guidebook.author.id.eq(authorId),
             GuidebookCondition.titleContains(keyword),
             GuidebookCursorCondition.buildUserGuidebookCursor(cursor, sortBy, direction),
-            isOwner ? null : GuidebookCondition.isPublished()
+            isOwner ? null : GuidebookCondition.isPublished(),
+            isOwner ? null : GuidebookCondition.isNotHidden()
         )
         .orderBy(GuidebookOrderBuilder.forUserGuidebook(sortBy, direction))
         .limit(limit)
@@ -93,7 +95,8 @@ public class GuidebookRepositoryCustomImpl implements GuidebookRepositoryCustom 
             guidebook.author.id.eq(authorId),
             GuidebookCondition.isNotDeleted(),
             GuidebookCondition.titleContains(keyword),
-            isOwner ? null : GuidebookCondition.isPublished()
+            isOwner ? null : GuidebookCondition.isPublished(),
+            isOwner ? null : GuidebookCondition.isNotHidden()
         )
         .fetchOne();
 
@@ -106,6 +109,7 @@ public class GuidebookRepositoryCustomImpl implements GuidebookRepositoryCustom 
 
     where.and(GuidebookCondition.isNotDeleted());
     where.and(GuidebookCondition.isPublished());
+    where.and(GuidebookCondition.isNotHidden());
     where.and(GuidebookCondition.titleContains(keyword));
     where.and(GuidebookCondition.isLocalGuidebook(isLocal));
 
@@ -146,6 +150,7 @@ public class GuidebookRepositoryCustomImpl implements GuidebookRepositoryCustom 
     where.and(guidebookPlace.place.id.eq(placeId));
     where.and(GuidebookCondition.isNotDeleted());
     where.and(GuidebookCondition.isPublished());
+    where.and(GuidebookCondition.isNotHidden());
     where.and(GuidebookCondition.titleContains(keyword));
     where.and(GuidebookCondition.isLocalGuidebook(isLocal));
     where.and(GuidebookCursorCondition.buildGuidebookCursor(cursor, sortBy, direction));
@@ -168,6 +173,7 @@ public class GuidebookRepositoryCustomImpl implements GuidebookRepositoryCustom 
             guidebookPlace.place.id.eq(placeId),
             GuidebookCondition.isNotDeleted(),
             GuidebookCondition.isPublished(),
+            GuidebookCondition.isNotHidden(),
             GuidebookCondition.titleContains(keyword),
             GuidebookCondition.isLocalGuidebook(isLocal))
         .fetchOne();

--- a/src/main/java/region/jidogam/domain/guidebook/service/GuidebookService.java
+++ b/src/main/java/region/jidogam/domain/guidebook/service/GuidebookService.java
@@ -258,6 +258,11 @@ public class GuidebookService {
 
     Guidebook guidebook = getOrThrow(id);
 
+    if (Boolean.TRUE.equals(guidebook.getAdminHidden())
+        && !guidebook.getAuthor().getId().equals(userId)) {
+      throw GuidebookNotFoundException.withId(id);
+    }
+
     int visitedPlaceCount = getVisitedPlaceCount(guidebook.getId(), userId);
 
     return guidebookMapper.toResponse(guidebook, visitedPlaceCount);

--- a/src/main/java/region/jidogam/domain/guidebook/service/GuidebookService.java
+++ b/src/main/java/region/jidogam/domain/guidebook/service/GuidebookService.java
@@ -260,7 +260,7 @@ public class GuidebookService {
 
     if (Boolean.TRUE.equals(guidebook.getAdminHidden())
         && !guidebook.getAuthor().getId().equals(userId)) {
-      throw GuidebookNotFoundException.withId(id);
+      return guidebookMapper.toHiddenResponse(guidebook);
     }
 
     int visitedPlaceCount = getVisitedPlaceCount(guidebook.getId(), userId);

--- a/src/main/java/region/jidogam/domain/user/service/UserService.java
+++ b/src/main/java/region/jidogam/domain/user/service/UserService.java
@@ -368,7 +368,10 @@ public class UserService {
     // GuidebookParticipant -> GuidebookParticipantResponse 변환
     List<GuidebookParticipationResponse> responses = participants.stream()
         .map(participant -> GuidebookParticipationResponse.builder()
-            .guidebookResponse(guidebookMapper.toResponse(participant.getGuidebook()))
+            .guidebookResponse(
+                Boolean.TRUE.equals(participant.getGuidebook().getAdminHidden())
+                    ? guidebookMapper.toHiddenResponse(participant.getGuidebook())
+                    : guidebookMapper.toResponse(participant.getGuidebook()))
             .lastActivityAt(participant.getLastActivityAt())
             .isCompleted(participant.getIsCompleted())
             .build())


### PR DESCRIPTION
## #️⃣연관된 이슈

- #165

## 📝 PR 유형

- [x] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug Fix)
- [ ] 코드 개선 (Refactoring)
- [ ] 문서 작업 (Documentation)
- [ ] 환경 설정 (Configuration)
- [ ] 기타 (Other)

## 📝작업 내용

> 관리자가 숨김 처리한 가이드북(`adminHidden = true`)이 일반 사용자 조회 쿼리에 노출되던 문제를 보완하고, 응답에 `isHidden` 필드를 추가하여 숨김 상태를 클라이언트가 인지할 수 있도록 합니다.

### 배경

`#165` 관리자 가이드북 관리 기능에서 `adminHidden` 컬럼을 추가하고 관리자가 가이드북을 숨김 처리할 수 있도록 했으나, 일반 사용자 측 조회 쿼리에 hide 필터가 빠져 있어서 관리자가 숨겨도 사용자 노출이 차단되지 않는 문제가 있었습니다. 또한 참여 중인 가이드북 목록 / 상세 조회에서는 숨김 상태를 알 수 있는 방법이 없었습니다.

### 구현 내용

#### 1. 검색/목록 쿼리에 hide 필터 적용

- `GuidebookCondition.isNotHidden()` 추가 (`adminHidden = false`)
- `GuidebookRepositoryCustomImpl` 6개 쿼리에 `isNotHidden` 적용
  - `searchGuidebook` (전체 목록)
  - `countPublishedGuidebooksByKeyword` (전체 목록 카운트)
  - `searchGuidebooksByPlaceId` (장소별 가이드북 목록)
  - `countGuidebooksByPlaceId` (장소별 가이드북 카운트)
  - `searchGuidebookByAuthorId` / `countGuidebookByAuthorId`: `isOwner` 분기 (owner 본인 마이페이지에서는 숨김된 본인 가이드북도 노출 — admin이 숨겼다는 사실을 owner가 인지 가능하도록)

#### 2. `isHidden` 필드 추가 + 숨김 가이드북 마스킹 응답

- `GuidebookResponse`에 `Boolean isHidden` 필드 추가
- 기존 primitive 필드(`int exp`, `double score`, `int participantCount` 등)를 wrapper 타입(`Integer`, `Double`)으로 변경 → 숨김 마스킹 시 null 표현 가능
- `GuidebookMapper.toHiddenResponse(Guidebook)` 추가: `gid` + `isHidden=true`만 포함, 나머지 필드 모두 null로 반환
- `GuidebookMapper.toResponse`는 항상 `isHidden = guidebook.getAdminHidden()` 값을 포함

#### 3. 단건/참여중 가이드북 조회 시 마스킹 적용

- **`GuidebookService.getById`** (가이드북 상세)
  - 숨김 && 요청자가 author 아님 → `toHiddenResponse` (마스킹)
  - 숨김 && author 본인 → 정상 응답 (`isHidden=true`로 표시)
  - 비숨김 → 정상 응답 (`isHidden=false`)
- **`UserService.getUserParticipation`** (참여 중인 가이드북 목록)
  - 각 participation 매핑 시 가이드북이 숨김 상태면 마스킹 응답으로 대체
  - 커서 인코딩은 `lastActivityAt` / `gid` 기반이라 마스킹 응답으로도 정상 작동

### 수정된 파일

- `src/main/java/region/jidogam/domain/guidebook/repository/querydsl/GuidebookCondition.java`
- `src/main/java/region/jidogam/domain/guidebook/repository/querydsl/GuidebookRepositoryCustomImpl.java`
- `src/main/java/region/jidogam/domain/guidebook/service/GuidebookService.java`
- `src/main/java/region/jidogam/domain/guidebook/dto/GuidebookResponse.java`
- `src/main/java/region/jidogam/domain/guidebook/mapper/GuidebookMapper.java`
- `src/main/java/region/jidogam/domain/user/service/UserService.java`

### 응답 예시

**일반 가이드북 응답**
```json
{
  "gid": "...",
  "isHidden": false,
  "title": "제주 한바퀴",
  "description": "...",
  "score": 4.5,
  "participantCount": 12,
  ...
}
```

**숨김 가이드북 마스킹 응답 (비owner 상세 조회 / 참여중인 목록 항목)**
```json
{
  "gid": "...",
  "isHidden": true,
  "title": null,
  "description": null,
  "score": null,
  "participantCount": null,
  ...
}
```

### 스크린샷 (선택)

> 필요 시 첨부

## 💬리뷰 요구사항(선택)

- **owner 분기 정책**: 작성자별 목록(`searchGuidebookByAuthorId`)은 기존 `isPublished` 패턴을 따라 `isOwner ? null : isNotHidden()`으로 처리했습니다. owner 본인은 admin이 숨긴 자기 가이드북을 마이페이지에서 볼 수 있는데, 이 정책이 적절할지 확인 부탁드립니다. (UI에서 "관리자에 의해 숨김 처리됨" 표시 함께 노출 권장)
- **상세 조회(`getById`) author 정책**: 숨김 시 author 본인은 풀 응답(`isHidden=true` 포함), 그 외 사용자는 마스킹 응답으로 처리했습니다. author 본인도 마스킹하는 게 일관적일 수 있는데, 의견 부탁드립니다.
- **참여중 가이드북 응답의 author 처리**: 참여중인 목록에서는 author 본인 여부와 무관하게 숨김이면 무조건 마스킹합니다. (참여중 목록은 "내가 참여중인 것"이라는 관점이라 author 여부 분기 생략) 이 정책이 맞을지 확인 부탁드립니다.
- **DTO primitive → wrapper 변경**: 마스킹 시 null 표현을 위해 `int/double` → `Integer/Double` 변경했습니다. JSON 응답 호환성에는 문제 없으나 변경 사항이라 짚어둡니다.

## #️⃣닫을 이슈

<!-- 닫을 이슈 번호를 입력해주세요. -->

close #165
