### PR TITLE
feat: 출판 / 출판 취소 API 분리

### DIFF
--- a/src/main/java/region/jidogam/domain/guidebook/controller/GuidebookApi.java
+++ b/src/main/java/region/jidogam/domain/guidebook/controller/GuidebookApi.java
@@ -112,6 +112,33 @@ public interface GuidebookApi {
       @Parameter(hidden = true) @CurrentUserId UUID userId
   );
 
+  @Operation(summary = "가이드북 출판", description = "가이드북을 출판합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "출판 성공",
+          content = @Content(schema = @Schema(implementation = GuidebookResponse.class))),
+      @ApiResponse(responseCode = "400", description = "출판 조건을 충족하지 못함"),
+      @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+      @ApiResponse(responseCode = "403", description = "권한 없음"),
+      @ApiResponse(responseCode = "404", description = "가이드북을 찾을 수 없음")
+  })
+  ResponseEntity<GuidebookResponse> publish(
+      @Parameter(description = "가이드북 ID", required = true) @PathVariable UUID id,
+      @Parameter(hidden = true) @CurrentUserId UUID userId
+  );
+
+  @Operation(summary = "가이드북 출판 취소", description = "가이드북 출판을 취소합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "204", description = "출판 취소 성공"),
+      @ApiResponse(responseCode = "400", description = "참여자가 존재하여 출판 취소 불가"),
+      @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+      @ApiResponse(responseCode = "403", description = "권한 없음"),
+      @ApiResponse(responseCode = "404", description = "가이드북을 찾을 수 없음")
+  })
+  ResponseEntity<Void> unpublish(
+      @Parameter(description = "가이드북 ID", required = true) @PathVariable UUID id,
+      @Parameter(hidden = true) @CurrentUserId UUID userId
+  );
+
   @Operation(summary = "가이드북 장소 목록 조회", description = "가이드북에 포함된 장소 목록을 조회합니다.")
   @ApiResponses(value = {
       @ApiResponse(responseCode = "200", description = "장소 목록 조회 성공"),

--- a/src/main/java/region/jidogam/domain/guidebook/controller/GuidebookController.java
+++ b/src/main/java/region/jidogam/domain/guidebook/controller/GuidebookController.java
@@ -111,6 +111,26 @@ public class GuidebookController implements GuidebookApi {
   }
 
   @Override
+  @PostMapping("/{id}/publish")
+  public ResponseEntity<GuidebookResponse> publish(
+      @PathVariable UUID id,
+      @CurrentUserId UUID userId
+  ) {
+    GuidebookResponse response = guidebookService.publish(id, userId);
+    return ResponseEntity.ok(response);
+  }
+
+  @Override
+  @PatchMapping("/{id}/unpublish")
+  public ResponseEntity<Void> unpublish(
+      @PathVariable UUID id,
+      @CurrentUserId UUID userId
+  ) {
+    guidebookService.unpublish(id, userId);
+    return ResponseEntity.noContent().build();
+  }
+
+  @Override
   @GetMapping("/{id}/places")
   public ResponseEntity<CursorPageResponseDto<PlaceResponse>> getPlaces(
       @PathVariable UUID id,

--- a/src/main/java/region/jidogam/domain/guidebook/dto/GuidebookUpdateRequest.java
+++ b/src/main/java/region/jidogam/domain/guidebook/dto/GuidebookUpdateRequest.java
@@ -19,10 +19,8 @@ public record GuidebookUpdateRequest(
     String color,
 
     @Schema(description = "가이드북 썸네일 key 값")
-    String thumbnail,
+    String thumbnail
 
-    @Schema(description = "가이드북 출판 여부")
-    Boolean isPublish
 ) {
 
 }

--- a/src/main/java/region/jidogam/domain/guidebook/entity/Guidebook.java
+++ b/src/main/java/region/jidogam/domain/guidebook/entity/Guidebook.java
@@ -115,6 +115,10 @@ public class Guidebook extends BaseUpdatableEntity {
     this.totalPlaceCount -= 1;
   }
 
+  public void setParticipantCount(int count) {
+    this.participantCount = count;
+  }
+
   public void publish() {
     this.isPublished = true;
     this.publishedDate = LocalDateTime.now();

--- a/src/main/java/region/jidogam/domain/guidebook/repository/GuidebookRepository.java
+++ b/src/main/java/region/jidogam/domain/guidebook/repository/GuidebookRepository.java
@@ -19,7 +19,7 @@ public interface GuidebookRepository extends JpaRepository<Guidebook, UUID>,
       WHERE g.id = :guidebookId
       AND g.participantCount + :delta >= 0
       """)
-  void updateParticipantCount(UUID guidebookId, int delta);
+  int updateParticipantCount(UUID guidebookId, int delta);
 
   @Modifying
   @Query("""

--- a/src/main/java/region/jidogam/domain/guidebook/service/GuidebookService.java
+++ b/src/main/java/region/jidogam/domain/guidebook/service/GuidebookService.java
@@ -272,16 +272,6 @@ public class GuidebookService {
 
     checkAuthorOrThrow(guidebook, userId);
 
-    Optional.ofNullable(request.isPublish()).ifPresent(isPublish -> {
-      if (isPublish) {
-        User user = getUserOrThrow(userId);
-        publish(guidebook, user);
-        guidebook.publish();
-      } else {
-        unpublish(guidebook);
-        guidebook.unpublish();
-      }
-    });
     Optional.ofNullable(request.thumbnail()).ifPresent(newImage -> {
       String oldImageKey = guidebook.getThumbnailUrl();
       guidebook.updateThumbnailUrl(newImage);
@@ -298,6 +288,55 @@ public class GuidebookService {
 
     return guidebookMapper.toResponse(guidebook, visitedPlaceCount);
   }
+
+  @Transactional
+  public GuidebookResponse publish(UUID id, UUID userId) {
+
+    Guidebook guidebook = getOrThrow(id);
+
+    checkAuthorOrThrow(guidebook, userId);
+
+    if (guidebook.getTotalPlaceCount() < publishMinPlaceCount) {
+      throw GuidebookPublishConditionException.insufficientPlaces(publishMinPlaceCount);
+    }
+
+    calculateAndSaveAreaRatio(guidebook);
+    applyTotalExp(guidebook);
+
+    User user = getUserOrThrow(userId);
+    int visitedPlaceCount = getVisitedPlaceCount(guidebook.getId(), userId);
+
+    GuidebookParticipation participation = GuidebookParticipation.builder()
+        .guidebook(guidebook)
+        .user(user)
+        .completedPlaceCount(visitedPlaceCount)
+        .lastActivityAt(LocalDateTime.now())
+        .build();
+    guidebookParticipantRepository.save(participation);
+    guidebook.setParticipantCount(1);
+
+    guidebook.publish();
+
+    return guidebookMapper.toResponse(guidebook, visitedPlaceCount);
+  }
+
+  @Transactional
+  public void unpublish(UUID id, UUID userId) {
+
+    Guidebook guidebook = getOrThrow(id);
+
+    checkAuthorOrThrow(guidebook, userId);
+
+    if (guidebook.getParticipantCount() > 0) {
+      throw GuidebookUnpublishViolationException.withId(guidebook.getId());
+    }
+
+    guidebook.invalidateAreaRatio();
+    guidebookAreaRatioRepository.deleteByGuidebook_Id(guidebook.getId());
+
+    guidebook.unpublish();
+  }
+
 
   @Transactional
   public void softDelete(UUID id, UUID userId) {
@@ -391,7 +430,17 @@ public class GuidebookService {
       throw GuidebookAlreadyParticipatedException.withId(guidebook.getId());
     }
 
-    addParticipantInternal(guidebook, user);
+    int completedCount = getVisitedPlaceCount(guidebook.getId(), userId);
+
+    GuidebookParticipation participation = GuidebookParticipation.builder()
+        .guidebook(guidebook)
+        .user(user)
+        .completedPlaceCount(completedCount)
+        .lastActivityAt(LocalDateTime.now())
+        .build();
+
+    guidebookParticipantRepository.save(participation);
+    guidebookRepository.updateParticipantCount(guidebook.getId(), 1);
   }
 
   @Transactional
@@ -441,12 +490,7 @@ public class GuidebookService {
     }
   }
 
-  // 이건 가이드북 수정과 별개로 분리하는게 가장 좋을 것 같음
-  private void publish(Guidebook guidebook, User user) {
-
-    if (guidebook.getTotalPlaceCount() < publishMinPlaceCount) {
-      throw GuidebookPublishConditionException.insufficientPlaces(publishMinPlaceCount);
-    }
+  private void calculateAndSaveAreaRatio(Guidebook guidebook) {
 
     // 모든 가이드북 장소-지역 중 top3 지역 가져오기
     List<AreaRatioDto> top3Areas = guidebookPlaceRepository.findAreasByPlaceCountDesc(
@@ -463,17 +507,16 @@ public class GuidebookService {
         ))
         .toList();
 
+    AreaRatioDto first = withRatios.get(0);
+
     // 장소 개수와 1위 지역의 비율에 따라 local 가이드북 확인
-    Boolean isLocalGuidebook = isLocalGuidebook(
-        withRatios.get(0).ratio(),
-        guidebook.getTotalPlaceCount()
-    );
+    boolean isLocal = isLocalGuidebook(first.ratio(), guidebook.getTotalPlaceCount());
 
     GuidebookAreaRatio guidebookAreaRatio = GuidebookAreaRatio.builder()
         .guidebook(guidebook)
-        .firstArea(withRatios.get(0).area())
-        .firstAreaRatio(withRatios.get(0).ratio())
-        .isPrimaryArea(isLocalGuidebook)
+        .firstArea(first.area())
+        .firstAreaRatio(first.ratio())
+        .isPrimaryArea(isLocal)
         .build();
 
     if (withRatios.size() > 1) {
@@ -483,15 +526,15 @@ public class GuidebookService {
       guidebookAreaRatio.setThirdArea(withRatios.get(2).area(), withRatios.get(2).ratio());
     }
 
-    // 가이드북 장소 전체 포인트 저장
+    guidebookAreaRatioRepository.save(guidebookAreaRatio);
+  }
+
+  private void applyTotalExp(Guidebook guidebook) {
     List<Place> places = guidebookPlaceRepository.findPlaceByGuidebookId(guidebook.getId());
-    int totalExps = places.stream()
+    int totalExp = places.stream()
         .mapToInt(Place::getExp)
         .sum();
-    guidebook.updateExp(totalExps);
-
-    guidebookAreaRatioRepository.save(guidebookAreaRatio);
-    addParticipantInternal(guidebook, user);
+    guidebook.updateExp(totalExp);
   }
 
   private double calculateRatio(long placeCount, int totalCount) {
@@ -513,28 +556,6 @@ public class GuidebookService {
     }
     // 30개 이상: 50% 이상
     return topRatio >= LARGE_GUIDEBOOK_LOCAL_RATIO;
-  }
-
-  private void unpublish(Guidebook guidebook) {
-    if (guidebook.getParticipantCount() > 0) {
-      throw GuidebookUnpublishViolationException.withId(guidebook.getId());
-    }
-    guidebook.invalidateAreaRatio();
-    guidebookAreaRatioRepository.deleteByGuidebook_Id(guidebook.getId());
-  }
-
-  private void addParticipantInternal(Guidebook guidebook, User user) {
-    int completedCount = getVisitedPlaceCount(guidebook.getId(), user.getId());
-
-    GuidebookParticipation participation = GuidebookParticipation.builder()
-        .guidebook(guidebook)
-        .user(user)
-        .completedPlaceCount(completedCount)
-        .lastActivityAt(LocalDateTime.now())
-        .build();
-
-    guidebookParticipantRepository.save(participation);
-    guidebookRepository.updateParticipantCount(guidebook.getId(), 1);
   }
 
 }

--- a/src/test/java/region/jidogam/domain/guidebook/service/GuidebookServiceTest.java
+++ b/src/test/java/region/jidogam/domain/guidebook/service/GuidebookServiceTest.java
@@ -260,7 +260,6 @@ class GuidebookServiceTest {
           "설명 수정",
           null,
           null,
-          null,
           null
       );
 
@@ -272,65 +271,66 @@ class GuidebookServiceTest {
       assertThat(response.description()).isEqualTo("설명 수정");
     }
 
+  }
+
+  @Nested
+  @DisplayName("가이드북 출판")
+  class Publish {
+
     @Test
-    @DisplayName("가이드북에 이미 참여자가 존재하는 경우, 출판 취소 불가능 예외 발생")
-    void failsByParticipantsExist() {
+    @DisplayName("출판 성공 - 소유자 참여 등록 및 출판 상태 변경")
+    void success() {
       // given
       UUID guidebookId = UUID.randomUUID();
       UUID userId = UUID.randomUUID();
 
-      Guidebook mockGuidebook = mock(Guidebook.class);
-      User mockUser = mock(User.class);
+      Guidebook guidebook = createGuidebook(userId, guidebookId, 10);
+      User user = createUser(userId);
 
-      when(guidebookRepository.findById(guidebookId)).thenReturn(Optional.of(mockGuidebook));
-      when(mockGuidebook.getAuthor()).thenReturn(mockUser);
-      when(mockUser.getId()).thenReturn(userId);
-      when(mockGuidebook.getParticipantCount()).thenReturn(1);
+      ReflectionTestUtils.setField(guidebookService, "publishMinPlaceCount", 5);
 
-      GuidebookUpdateRequest request = new GuidebookUpdateRequest(
-          null,
-          null,
-          null,
-          null,
-          null,
-          false
-      );
+      when(guidebookRepository.findById(guidebookId)).thenReturn(Optional.of(guidebook));
+      when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+      when(guidebookPlaceRepository.findAreasByPlaceCountDesc(guidebookId, PageRequest.of(0, 3)))
+          .thenReturn(List.of(new AreaRatioDto(mock(Area.class), 8L, 0.0)));
+      when(guidebookPlaceRepository.findPlaceByGuidebookId(guidebookId)).thenReturn(List.of());
+      when(expService.calculateGuidebookCompletionExp(anyInt()))
+          .thenAnswer(invocation -> invocation.getArgument(0));
 
-      // when & then
-      assertThrows(GuidebookUnpublishViolationException.class,
-          () -> guidebookService.update(guidebookId, userId, request));
+      // when
+      guidebookService.publish(guidebookId, userId);
+
+      // then
+      verify(guidebookParticipantRepository).save(any(GuidebookParticipation.class));
+      assertThat(guidebook.getParticipantCount()).isEqualTo(1);
+      assertThat(guidebook.getIsPublished()).isTrue();
     }
 
-    // 출판 시 엣지 조건 확인
     @Test
-    @DisplayName("최소 장소 수 이하인 경우 가이드북 출판 시도 시 예외 발생")
+    @DisplayName("최소 장소 수 이하인 경우 출판 시도 시 예외 발생")
     void failsByInsufficientPlaceCount() {
       // given
       UUID guidebookId = UUID.randomUUID();
       UUID userId = UUID.randomUUID();
 
       Guidebook guidebook = createGuidebook(userId, guidebookId, 1);
-      User user = createUser(userId);
       ReflectionTestUtils.setField(guidebookService, "publishMinPlaceCount", 5);
 
       when(guidebookRepository.findById(guidebookId)).thenReturn(Optional.of(guidebook));
-      when(userRepository.findById(userId)).thenReturn(Optional.of(user));
 
       // when & then
       assertThrows(GuidebookPublishConditionException.class,
-          () -> guidebookService.update(guidebookId, userId,
-              new GuidebookUpdateRequest(null, null, null, null, null, true)));
+          () -> guidebookService.publish(guidebookId, userId));
     }
 
     @ParameterizedTest
     @CsvSource({
-        // totalCount, firstPlaceCount, isLocal
-        "9, 7, true",     // 9개 중 7개 = 77.78% → Local (70% 이상)
-        "9, 6, false",    // 9개 중 6개 = 66.67% → Not Local (70% 미만)
-        "10, 6, true",    // 10개 중 6개 = 60.0% → Local (60% 이상)
-        "10, 5, false",   // 10개 중 5개 = 50.0% → Not Local (60% 미만)
-        "30, 15, true",   // 30개 중 15개 = 50.0% → Local (50% 이상)
-        "30, 14, false"   // 30개 중 14개 = 46.67% → Not Local (50% 미만)
+        "9, 7, true",
+        "9, 6, false",
+        "10, 6, true",
+        "10, 5, false",
+        "30, 15, true",
+        "30, 14, false"
     })
     @DisplayName("장소 개수와 1위 지역 비율에 따른 Local 가이드북 판단")
     void determineLocalGuidebook(int totalCount, long firstPlaceCount, boolean expectedLocal) {
@@ -345,23 +345,72 @@ class GuidebookServiceTest {
           new AreaRatioDto(mock(Area.class), totalCount - firstPlaceCount, 0.0)
       );
 
+      ReflectionTestUtils.setField(guidebookService, "publishMinPlaceCount", 5);
+
       when(guidebookRepository.findById(guidebookId)).thenReturn(Optional.of(guidebook));
       when(userRepository.findById(userId)).thenReturn(Optional.of(user));
       when(guidebookPlaceRepository.findAreasByPlaceCountDesc(guidebookId, PageRequest.of(0, 3)))
           .thenReturn(areas);
+      when(guidebookPlaceRepository.findPlaceByGuidebookId(guidebookId)).thenReturn(List.of());
       when(expService.calculateGuidebookCompletionExp(anyInt()))
           .thenAnswer(invocation -> invocation.getArgument(0));
 
       // when
-      guidebookService.update(guidebookId, userId,
-          new GuidebookUpdateRequest(null, null, null, null, null, true));
+      guidebookService.publish(guidebookId, userId);
 
       // then
       verify(guidebookAreaRatioRepository).save(argThat(ratio ->
           ratio.getIsPrimaryArea() == expectedLocal
       ));
     }
+  }
 
+  @Nested
+  @DisplayName("가이드북 출판 취소")
+  class Unpublish {
+
+    @Test
+    @DisplayName("출판 취소 성공")
+    void success() {
+      // given
+      UUID guidebookId = UUID.randomUUID();
+      UUID userId = UUID.randomUUID();
+
+      Guidebook mockGuidebook = mock(Guidebook.class);
+      User mockUser = mock(User.class);
+
+      when(guidebookRepository.findById(guidebookId)).thenReturn(Optional.of(mockGuidebook));
+      when(mockGuidebook.getAuthor()).thenReturn(mockUser);
+      when(mockUser.getId()).thenReturn(userId);
+      when(mockGuidebook.getParticipantCount()).thenReturn(0);
+      when(mockGuidebook.getId()).thenReturn(guidebookId);
+
+      // when
+      guidebookService.unpublish(guidebookId, userId);
+
+      // then
+      verify(mockGuidebook).unpublish();
+    }
+
+    @Test
+    @DisplayName("참여자가 존재하는 경우 출판 취소 시 예외 발생")
+    void failsByParticipantsExist() {
+      // given
+      UUID guidebookId = UUID.randomUUID();
+      UUID userId = UUID.randomUUID();
+
+      Guidebook mockGuidebook = mock(Guidebook.class);
+      User mockUser = mock(User.class);
+
+      when(guidebookRepository.findById(guidebookId)).thenReturn(Optional.of(mockGuidebook));
+      when(mockGuidebook.getAuthor()).thenReturn(mockUser);
+      when(mockUser.getId()).thenReturn(userId);
+      when(mockGuidebook.getParticipantCount()).thenReturn(1);
+
+      // when & then
+      assertThrows(GuidebookUnpublishViolationException.class,
+          () -> guidebookService.unpublish(guidebookId, userId));
+    }
   }
 
   @Nested


### PR DESCRIPTION
## #️⃣연관된 이슈

#201

## 📝 PR 유형

<!-- 해당하는 유형에 'x'로 체크해주세요. -->

- [x] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug Fix)
- [ ] 코드 개선 (Refactoring)
- [ ] 문서 작업 (Documentation)
- [ ] 환경 설정 (Configuration)
- [ ] 기타 (Other)

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요 (이미지 첨부 가능)

  - 가이드북 출판/취소 로직을 `PATCH /{id}` (update API)에서 분리하여 독립 API로 구현                                                                                                                                               
  - `GuidebookUpdateRequest`에서 `isPublish` 필드 제거                                                                                                                                                                              
  - 출판 시 소유자 참여자 수 처리 방식 개선                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                    
  ### API 분리                                                                                                                                                                                                                      
  기존에는 가이드북 수정 API(`PATCH /{id}`)의 `isPublish` 필드로 출판/취소를 처리했습니다.                                                                                                                                          
  출판과 수정은 의미상 독립적인 작업이므로 별도 API로 분리했습니다.                                                                                                                                                                 
                                                                                                                                                                                                                                    
  | 기능 | 변경 전 | 변경 후 |                                                                                                                                                                                                      
  |------|---------|---------|                                                                                                                                                                                                      
  | 출판 | `PATCH /{id}` (isPublish: true) | `POST /{id}/publish` |                                                                                                                                                                 
  | 출판 취소 | `PATCH /{id}` (isPublish: false) | `PATCH /{id}/unpublish` |                                                                                                                                                        
                                                                                                                                                                                                                                    
  ### 출판 시 소유자 참여자 수 처리 개선                                                                                                                                                                                            
  출판 시 소유자를 자동으로 첫 번째 참여자로 등록하는 과정에서 `participantCount`를 원자적 쿼리(`@Modifying @Query`)로 증가시켰습니다.                                                                                              
                                                                                                                                                                                                                                    
  그러나 같은 트랜잭션 내에서 `guidebook.publish()`로 엔티티를 수정하면 dirty checking이 발생해, 원자적 쿼리로 올린 값이 영속성 컨텍스트의 이전 값으로 덮어씌워지는 문제가 있었습니다.                                              
                                                                                                                                                                                                                                    
  출판 시점은 아직 `isPublished = false` 상태이므로 다른 사용자의 동시 접근이 불가능합니다. 따라서 원자적 쿼리 대신 `guidebook.setParticipantCount(1)`로 직접 설정하고 dirty checking을 활용하도록 변경했습니다.                    
                                                                                                                                                                                                                                    
  (`@DynamicUpdate` 적용도 검토했으나, 출판 시점의 특성상 동시성 문제가 없어 불필요하다고 판단했습니다.)                                                                                                                            
                                                                                                                                                                                                                                    
  ### publish 흐름 순서 정리                                                                                                                                                                                                        
  준비(지역 비율 계산, 경험치 산정, 소유자 참여 등록)를 마친 후 마지막에 출판 상태로 변경하도록 순서를 조정했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## #️⃣닫을 이슈

<!-- 닫을 이슈 번호를 입력해주세요. -->

close #201